### PR TITLE
Add `Flow<Loadable<T?>>.unwrapContent` extension function

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -10,8 +10,8 @@ object Versions {
     val java = JavaVersion.VERSION_11
 
     object Loadable {
-        const val CODE = 4
-        const val NAME = "1.2.1"
+        const val CODE = 5
+        const val NAME = "1.3.0"
         const val SDK_COMPILE = 33
         const val SDK_MIN = 21
         const val SDK_TARGET = SDK_COMPILE

--- a/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
+++ b/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
@@ -159,7 +159,7 @@ internal class FlowExtensionsTests {
 
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
-    fun `GIVEN a Flow WHEN converting it into a Loadable in a CoroutineScope THEN Loading is only emitted once as an initial value`() { // ktlint-disable max-line-length
+    fun `GIVEN a Flow WHEN converting it into a Loadable one in a CoroutineScope THEN Loading is only emitted once as an initial value`() { // ktlint-disable max-line-length
         runTest {
             flowOf(0).loadable(this).test {
                 assertIs<Loadable.Loading<Int>>(awaitItem())
@@ -183,6 +183,25 @@ internal class FlowExtensionsTests {
                 .test {
                     assertEquals(8, awaitItem())
                     assertEquals(16, awaitItem())
+                    awaitComplete()
+                }
+        }
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun `GIVEN a Loadable Flow WHEN unwrapping its content THEN only Loaded values with non-null content are emitted`() { // ktlint-disable max-line-length
+        runTest {
+            emptyLoadableFlow {
+                load(null)
+                load(0)
+                load(null)
+                load(1)
+            }
+                .unwrapContent()
+                .test {
+                    assertEquals(Loadable.Loaded(0), awaitItem())
+                    assertEquals(Loadable.Loaded(1), awaitItem())
                     awaitComplete()
                 }
         }


### PR DESCRIPTION
Adds an extension function for a [`Flow`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/-flow/) of [`Loadable`](https://github.com/jeanbarrossilva/loadable/blob/7ed4f914a9c7f34a64d3715f669bc66109458670/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.kt)s whose values might be null that returns only [`Loadable`](https://github.com/jeanbarrossilva/loadable/blob/7ed4f914a9c7f34a64d3715f669bc66109458670/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.kt)s with values that aren't.