### PR TITLE
Inline `Loadable`s

### DIFF
--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.kt
@@ -16,12 +16,14 @@ sealed interface Loadable<T : Serializable?> : Serializable {
      *
      * @param value Content that's been successfully loaded.
      **/
-    data class Loaded<T : Serializable?>(val value: T) : Loadable<T>
+    @JvmInline
+    value class Loaded<T : Serializable?>(val value: T) : Loadable<T>
 
     /**
      * Stage in which the content has failed to load and threw [error].
      *
      * @param error [Throwable] that's been thrown while trying to load the content.
      **/
-    data class Failed<T : Serializable?>(val error: Throwable) : Loadable<T>
+    @JvmInline
+    value class Failed<T : Serializable?>(val error: Throwable) : Loadable<T>
 }


### PR DESCRIPTION
Turns [`Loadable.Loaded`](https://github.com/jeanbarrossilva/loadable/blob/31a9e3298a3c7981aa6d62ab92d4241990cced12/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.kt#L20) and [`Loadable.Failed`](https://github.com/jeanbarrossilva/loadable/blob/31a9e3298a3c7981aa6d62ab92d4241990cced12/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.kt#L28) into [inlined classes](https://kotlinlang.org/docs/inline-classes.html).