### PR TITLE
Rename loaded value to "content"

### DIFF
--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.extensions.kt
@@ -3,37 +3,38 @@ package com.jeanbarrossilva.loadable
 import java.io.Serializable
 
 /**
- * [Value][Loadable.Loaded.value] of the given [Loadable] if it's [loaded][Loadable.Loaded];
+ * [Content][Loadable.Loaded.content] of the given [Loadable] if it's [loaded][Loadable.Loaded];
  * otherwise, `null`.
  **/
-inline val <T : Serializable?> Loadable<T>.valueOrNull
+inline val <T : Serializable?> Loadable<T>.contentOrNull
     get() = ifLoaded { this }
 
 /**
  * Returns the result of the given [operation] that's ran on the [loaded][Loadable.Loaded]
- * [value][Loadable.Loaded.value]; if the [Loadable] is not a [Loadable.Loaded], returns `null`.
+ * [content][Loadable.Loaded.content]; if the [Loadable] is not a [Loadable.Loaded], returns `null`.
  *
- * @param operation Lambda whose result will get returned if this is a [Loadable.Loaded].
+ * @param operation Callback to be run on the [loaded][Loadable.Loaded]
+ * [content][Loadable.Loaded.content].
  **/
 inline fun <I : Serializable?, O> Loadable<I>.ifLoaded(operation: I.() -> O): O? {
-    return if (this is Loadable.Loaded) value.operation() else null
+    return if (this is Loadable.Loaded) content.operation() else null
 }
 
 /**
  * If the receiver [Loadable] is [loaded][Loadable.Loaded], applies [transform] on its
- * [value][Loadable.Loaded.value] and creates a new [Loadable.Loaded] containing it.
+ * [content][Loadable.Loaded.content] and creates a new [Loadable.Loaded] containing it.
  *
  * Otherwise, creates an instance of a [Loadable] that's equivalent to the given one but with [O] as
  * its type parameter.
  *
  * @param transform Transformation to be done to the [loaded][Loadable.Loaded]
- * [value][Loadable.Loaded.value].
+ * [content][Loadable.Loaded.content].
  **/
 inline fun <I : Serializable?, O : Serializable?> Loadable<I>.map(transform: (I) -> O):
     Loadable<O> {
     return when (this) {
         is Loadable.Loading -> Loadable.Loading()
-        is Loadable.Loaded -> Loadable.Loaded(transform(value))
+        is Loadable.Loaded -> Loadable.Loaded(transform(content))
         is Loadable.Failed -> Loadable.Failed(error)
     }
 }

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.kt
@@ -12,12 +12,12 @@ sealed interface Loadable<T : Serializable?> : Serializable {
     }
 
     /**
-     * Stage in which the content has been loaded and is represented by [value].
+     * Stage in which the content has been successfully loaded.
      *
-     * @param value Content that's been successfully loaded.
+     * @param content Value that's been loaded.
      **/
     @JvmInline
-    value class Loaded<T : Serializable?>(val value: T) : Loadable<T>
+    value class Loaded<T : Serializable?>(val content: T) : Loadable<T>
 
     /**
      * Stage in which the content has failed to load and threw [error].

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/LoadableScope.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/LoadableScope.kt
@@ -10,12 +10,12 @@ abstract class LoadableScope<T : Serializable?> internal constructor() {
     }
 
     /**
-     * Sends a [Loadable.Loaded] with the given [value].
+     * Sends a [Loadable.Loaded] with the given [content].
      *
-     * @param value Value to be set as the [Loadable.Loaded.value].
+     * @param content Value to be set as the [Loadable.Loaded.content].
      **/
-    suspend fun load(value: T) {
-        send(Loadable.Loaded(value))
+    suspend fun load(content: T) {
+        send(Loadable.Loaded(content))
     }
 
     /**

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/Flow.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/Flow.extensions.kt
@@ -74,17 +74,17 @@ fun <T : Serializable?> Flow<T>.loadable(): Flow<Loadable<T>> {
 
 /**
  * Unwraps [Loadable.Loaded] emissions and returns a [Flow] containing only their
- * [Loadable.Loaded.value]s.
+ * [content][Loadable.Loaded.content]s.
  **/
 fun <T : Serializable?> Flow<Loadable<T>>.unwrap(): Flow<T> {
     return filterIsLoaded().map {
-        it.value
+        it.content
     }
 }
 
 /**
  * Unwraps [Loadable.Loaded] emissions and returns a [Flow] containing only those that have a
- * non-`null` [value][Loadable.Loaded.value].
+ * non-`null` [content][Loadable.Loaded.content].
  **/
 fun <T : Serializable> Flow<Loadable<T?>>.unwrapContent(): Flow<Loadable<T>> {
     @Suppress("UNCHECKED_CAST")

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/MutableStateFlow.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/MutableStateFlow.extensions.kt
@@ -9,7 +9,7 @@ internal fun <T : Serializable?> loadable(): MutableStateFlow<Loadable<T>> {
     return MutableStateFlow(Loadable.Loading())
 }
 
-/** Creates a [MutableStateFlow] with a [Loadable.Loaded] that wraps the given [value]. **/
-internal fun <T : Serializable?> loadable(value: T): MutableStateFlow<Loadable<T>> {
-    return MutableStateFlow(Loadable.Loaded(value))
+/** Creates a [MutableStateFlow] with a [Loadable.Loaded] that wraps the given [content]. **/
+internal fun <T : Serializable?> loadable(content: T): MutableStateFlow<Loadable<T>> {
+    return MutableStateFlow(Loadable.Loaded(content))
 }

--- a/loadable/src/test/java/com/jeanbarrossilva/loadable/LoadableTests.kt
+++ b/loadable/src/test/java/com/jeanbarrossilva/loadable/LoadableTests.kt
@@ -9,18 +9,18 @@ import org.junit.Test
 
 internal class LoadableTests {
     @Test
-    fun `GIVEN a Loading Loadable WHEN getting its value THEN it's null`() {
-        assertNull(Loadable.Loading<Int>().valueOrNull)
+    fun `GIVEN a Loading Loadable WHEN getting its content THEN it's null`() {
+        assertNull(Loadable.Loading<Int>().contentOrNull)
     }
 
     @Test
-    fun `GIVEN a Loaded Loadable WHEN getting its value THEN it isn't null`() {
-        assertEquals(0, Loadable.Loaded(0).valueOrNull)
+    fun `GIVEN a Loaded Loadable WHEN getting its content THEN it isn't null`() {
+        assertEquals(0, Loadable.Loaded(0).contentOrNull)
     }
 
     @Test
-    fun `GIVEN a Failed Loadable WHEN getting its value THEN it's null`() {
-        assertNull(Loadable.Failed<Int>(Throwable()).valueOrNull)
+    fun `GIVEN a Failed Loadable WHEN getting its content THEN it's null`() {
+        assertNull(Loadable.Failed<Int>(Throwable()).contentOrNull)
     }
 
     @Test
@@ -44,7 +44,7 @@ internal class LoadableTests {
     }
 
     @Test
-    fun `GIVEN a Loaded Loadable WHEN mapping it THEN its value is transformed`() {
+    fun `GIVEN a Loaded Loadable WHEN mapping it THEN its content is transformed`() {
         assertEquals(
             Loadable.Loaded("Hello, ").map { it + "Jean!" },
             Loadable.Loaded("Hello, Jean!")

--- a/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
+++ b/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
@@ -171,7 +171,7 @@ internal class FlowExtensionsTests {
     @Test
     @Suppress("SpellCheckingInspection", "KotlinConstantConditions")
     @OptIn(ExperimentalCoroutinesApi::class)
-    fun `GIVEN a Loadable Flow WHEN unwrapping it THEN only Loaded Loadables' values are emitted`() { // ktlint-disable max-line-length
+    fun `GIVEN a Loadable Flow WHEN unwrapping it THEN only Loaded Loadables' contents are emitted`() { // ktlint-disable max-line-length
         runTest {
             loadableFlow {
                 load(8)


### PR DESCRIPTION
Renames [`Loadable.Loaded`](https://github.com/jeanbarrossilva/loadable/blob/01356d40ceb6d3f653a7e370f824527e799e7922/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.kt#L20)'s `value` property to "content".