### PR TITLE
Move `Loadable`-`MutableStateFlow`-creator functions to their own file

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -10,8 +10,8 @@ object Versions {
     val java = JavaVersion.VERSION_11
 
     object Loadable {
-        const val CODE = 7
-        const val NAME = "1.3.2"
+        const val CODE = 8
+        const val NAME = "1.4.0"
         const val SDK_COMPILE = 33
         const val SDK_MIN = 21
         const val SDK_TARGET = SDK_COMPILE

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/Flow.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/Flow.extensions.kt
@@ -9,7 +9,6 @@ import kotlin.experimental.ExperimentalTypeInference
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
@@ -129,16 +128,6 @@ fun <T : Serializable?> loadableFlow(load: suspend LoadableScope<T>.() -> Unit):
         load()
         load.invoke(this)
     }
-}
-
-/** Creates a [MutableStateFlow] with a [Loadable.Loading] as its initial value. **/
-fun <T : Serializable?> loadableFlow(): MutableStateFlow<Loadable<T>> {
-    return MutableStateFlow(Loadable.Loading())
-}
-
-/** Creates a [MutableStateFlow] with a [Loadable.Loaded] that wraps the given [content]. **/
-fun <T : Serializable?> loadableFlowOf(content: T): MutableStateFlow<Loadable<T>> {
-    return MutableStateFlow(Loadable.Loaded(content))
 }
 
 /**

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/MutableStateFlow.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/MutableStateFlow.extensions.kt
@@ -1,0 +1,15 @@
+package com.jeanbarrossilva.loadable.flow
+
+import com.jeanbarrossilva.loadable.Loadable
+import java.io.Serializable
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/** Creates a [MutableStateFlow] with a [Loadable.Loading] as its initial value. **/
+fun <T : Serializable?> loadableFlow(): MutableStateFlow<Loadable<T>> {
+    return MutableStateFlow(Loadable.Loading())
+}
+
+/** Creates a [MutableStateFlow] with a [Loadable.Loaded] that wraps the given [content]. **/
+fun <T : Serializable?> loadableFlowOf(content: T): MutableStateFlow<Loadable<T>> {
+    return MutableStateFlow(Loadable.Loaded(content))
+}

--- a/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
+++ b/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
@@ -179,7 +179,7 @@ internal class FlowExtensionsTests {
     }
 
     @Test
-    @Suppress("SpellCheckingInspection", "KotlinConstantConditions")
+    @Suppress("SpellCheckingInspection")
     @OptIn(ExperimentalCoroutinesApi::class)
     fun `GIVEN a Loadable Flow WHEN unwrapping it THEN only Loaded Loadables' contents are emitted`() { // ktlint-disable max-line-length
         runTest {


### PR DESCRIPTION
These were moved to `Flow.extensions.kt` by mistake.