### PR TITLE
Add terminal `Flow`-to-`LoadableScope`-sender operator

### DIFF
--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/LoadableScope.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/LoadableScope.kt
@@ -32,5 +32,5 @@ abstract class LoadableScope<T : Serializable?> internal constructor() {
      *
      * @param loadable [Loadable] to be sent.
      **/
-    protected abstract suspend fun send(loadable: Loadable<T>)
+    internal abstract suspend fun send(loadable: Loadable<T>)
 }

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/Flow.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/Flow.extensions.kt
@@ -73,7 +73,7 @@ fun <T : Serializable?> Flow<T>.loadable(): Flow<Loadable<T>> {
 
 /**
  * Terminal operator that sends [Loadable]s emitted to this [Flow] into the given [loadableScope],
- * calling its...
+ * analogue to calling its...
  *
  * - [LoadableScope.load] when [loading][Loadable.Loading];
  * - [LoadableScope.load] with the [content][Loadable.Loaded.content] when
@@ -81,13 +81,7 @@ fun <T : Serializable?> Flow<T>.loadable(): Flow<Loadable<T>> {
  * - [LoadableScope.fail] with the [error][Loadable.Failed.error] when [failed][Loadable.Failed].
  **/
 suspend fun <T : Serializable?> Flow<Loadable<T>>.sendTo(loadableScope: LoadableScope<T>) {
-    collect {
-        when (it) {
-            is Loadable.Loading -> loadableScope.load()
-            is Loadable.Loaded -> loadableScope.load(it.content)
-            is Loadable.Failed -> loadableScope.fail(it.error)
-        }
-    }
+    collect(loadableScope::send)
 }
 
 /**

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/Flow.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/Flow.extensions.kt
@@ -173,7 +173,7 @@ fun <T : Serializable?> loadableChannelFlow(
  * @param load Operations to be made on the [LoadableScope] responsible for emitting [Loadable]s
  * sent to it to the created [Flow].
  **/
-internal fun <T : Serializable?> emptyLoadableFlow(load: suspend LoadableScope<T>.() -> Unit = { }):
+internal fun <T : Serializable?> emptyLoadableFlow(load: suspend LoadableScope<T>.() -> Unit):
     Flow<Loadable<T>> {
     return flow<Loadable<T>> {
         FlowCollectorLoadableScope(this).apply {

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/Flow.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/Flow.extensions.kt
@@ -80,7 +80,7 @@ fun <T : Serializable?> Flow<T>.loadable(): Flow<Loadable<T>> {
  * [loaded][Loadable.Loaded];
  * - [LoadableScope.fail] with the [error][Loadable.Failed.error] when [failed][Loadable.Failed].
  **/
-suspend fun <T : Serializable?> Flow<Loadable<T>>.loadInto(loadableScope: LoadableScope<T>) {
+suspend fun <T : Serializable?> Flow<Loadable<T>>.sendTo(loadableScope: LoadableScope<T>) {
     collect {
         when (it) {
             is Loadable.Loading -> loadableScope.load()

--- a/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
+++ b/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
@@ -12,8 +12,8 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 
 internal class FlowExtensionsTests {
-    @Test
     @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
     fun `GIVEN a Loadable Flow built through a scope WHEN loading THEN a Loading has been emitted`() { // ktlint-disable max-line-length
         runTest {
             loadableFlow<Serializable?> { load() }.test {
@@ -23,8 +23,8 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @Test
     @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
     fun `GIVEN a Loadable Flow built through a scope WHEN loaded THEN a Loaded has been emitted`() {
         runTest {
             loadableFlow<Serializable?> { load(null) }.unwrap().test {
@@ -34,8 +34,8 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @Test
     @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
     fun `GIVEN a Loadable Flow built through a scope WHEN failed THEN a Failed has been emitted`() {
         runTest {
             loadableFlow<Serializable?> { fail(NullPointerException()) }.filterIsFailed().test {
@@ -45,8 +45,8 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @Test
     @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
     fun `GIVEN a Loadable Flow without an initial content WHEN collecting it THEN the value that's emitted first is a Loading one`() { // ktlint-disable max-line-length
         runTest {
             loadableFlow<Serializable>().test {
@@ -55,8 +55,8 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @Test
     @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
     fun `GIVEN a Loadable Flow with an initial content WHEN collecting it THEN the value that's emitted first is a Loaded one`() { // ktlint-disable max-line-length
         runTest {
             loadableFlowOf(0).test {
@@ -65,8 +65,8 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @Test
     @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
     fun `GIVEN a Loadable Flow WHEN filtering Failed values THEN they're all emitted`() {
         runTest {
             flow {
@@ -82,8 +82,8 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @Test
     @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
     fun `GIVEN a Loadable Flow WHEN filtering Loaded values THEN they're all emitted`() {
         runTest {
             loadableFlow {
@@ -102,8 +102,8 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @Test
     @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
     fun `GIVEN a Loadable Flow WHEN inner-mapping it THEN the emitted values are transformed`() {
         runTest {
             loadableFlow {
@@ -122,8 +122,8 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @Test
     @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
     fun `GIVEN a Flow WHEN converting it into a Loadable one THEN the value that's emitted first is a Loaded one`() { // ktlint-disable max-line-length
         runTest {
             flow { emit(true) }.loadable().test {
@@ -134,8 +134,8 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @Test
     @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
     fun `GIVEN a Flow WHEN converting it into a Loadable one THEN its values are emitted as Loaded`() { // ktlint-disable max-line-length
         runTest {
             flow {
@@ -152,9 +152,9 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @Test
-    @Suppress("DIVISION_BY_ZERO")
     @OptIn(ExperimentalCoroutinesApi::class)
+    @Suppress("DIVISION_BY_ZERO")
+    @Test
     fun `GIVEN a Flow WHEN converting it into a Loadable one THEN thrown exceptions are emitted as Failed`() { // ktlint-disable max-line-length
         runTest {
             flow<Serializable> { 0 / 0 }
@@ -167,8 +167,8 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @Test
     @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
     fun `GIVEN a Flow WHEN converting it into a Loadable one in a CoroutineScope THEN Loading is only emitted once as an initial value`() { // ktlint-disable max-line-length
         runTest {
             flowOf(0).loadable(this).test {
@@ -178,9 +178,9 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @Test
     @OptIn(ExperimentalCoroutinesApi::class)
     @Suppress("SpellCheckingInspection")
+    @Test
     fun `GIVEN a Loadable Flow WHEN unwrapping it THEN only Loaded Loadables' contents are emitted`() { // ktlint-disable max-line-length
         runTest {
             loadableFlow {
@@ -198,8 +198,8 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @Test
     @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
     fun `GIVEN a Loadable Flow WHEN unwrapping its content THEN only Loaded values with non-null content are emitted`() { // ktlint-disable max-line-length
         runTest {
             emptyLoadableFlow {
@@ -217,9 +217,9 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @Test
     @OptIn(ExperimentalCoroutinesApi::class)
     @Suppress("SpellCheckingInspection")
+    @Test
     fun `GIVEN a Loadable Flow that's Loading WHEN sending its Loadables  into a LoadableScope THEN it loads`() { // ktlint-disable max-line-length
         runTest {
             emptyLoadableFlow(loadableFlow<Serializable?>()::sendTo).test {
@@ -228,9 +228,9 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @Test
     @OptIn(ExperimentalCoroutinesApi::class)
     @Suppress("SpellCheckingInspection")
+    @Test
     fun `GIVEN a Loadable Flow that's Loaded WHEN sending its Loadables into a LoadableScope THEN it loads the content`() { // ktlint-disable max-line-length
         runTest {
             loadableFlow(loadableFlowOf(0)::sendTo).test {
@@ -240,9 +240,9 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @Test
     @OptIn(ExperimentalCoroutinesApi::class)
     @Suppress("SpellCheckingInspection")
+    @Test
     fun `GIVEN a Loadable Flow that's Failed WHEN sending its Loadables into a LoadableScope THEN it fails`() { // ktlint-disable max-line-length
         val error = Throwable()
         runTest {
@@ -257,9 +257,9 @@ internal class FlowExtensionsTests {
         }
     }
 
-    @Test
-    @Suppress("CAST_NEVER_SUCCEEDS")
     @OptIn(ExperimentalCoroutinesApi::class)
+    @Suppress("CAST_NEVER_SUCCEEDS")
+    @Test
     fun `GIVEN a Loadable ChannelFlow WHEN emitting from different scopes THEN it receives sent emissions`() { // ktlint-disable max-line-length
         runTest {
             loadableChannelFlow {

--- a/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
+++ b/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
@@ -218,6 +218,43 @@ internal class FlowExtensionsTests {
     }
 
     @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun `GIVEN a Loadable Flow that's Loading WHEN loading it into a LoadableScope THEN it loads`() { // ktlint-disable max-line-length
+        runTest {
+            emptyLoadableFlow(loadableFlow<Serializable?>()::loadInto).test {
+                assertIs<Loadable.Loading<Serializable?>>(awaitItem())
+            }
+        }
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun `GIVEN a Loadable Flow that's Loaded WHEN loading it into a LoadableScope THEN it loads the content`() { // ktlint-disable max-line-length
+        runTest {
+            loadableFlow(loadableFlowOf(0)::loadInto).test {
+                awaitItem()
+                assertEquals(Loadable.Loaded(0), awaitItem())
+            }
+        }
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun `GIVEN a Loadable Flow that's Failed WHEN loading it into a LoadableScope THEN it fails`() {
+        val error = Throwable()
+        runTest {
+            loadableFlow {
+                emptyLoadableFlow<Serializable?> { fail(error) }.loadInto(this)
+            }
+                .test {
+                    awaitItem()
+                    assertEquals(Loadable.Failed<Serializable?>(error), awaitItem())
+                    awaitComplete()
+                }
+        }
+    }
+
+    @Test
     @Suppress("CAST_NEVER_SUCCEEDS")
     @OptIn(ExperimentalCoroutinesApi::class)
     fun `GIVEN a Loadable ChannelFlow WHEN emitting from different scopes THEN it receives sent emissions`() { // ktlint-disable max-line-length

--- a/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
+++ b/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
@@ -179,8 +179,8 @@ internal class FlowExtensionsTests {
     }
 
     @Test
-    @Suppress("SpellCheckingInspection")
     @OptIn(ExperimentalCoroutinesApi::class)
+    @Suppress("SpellCheckingInspection")
     fun `GIVEN a Loadable Flow WHEN unwrapping it THEN only Loaded Loadables' contents are emitted`() { // ktlint-disable max-line-length
         runTest {
             loadableFlow {
@@ -219,9 +219,10 @@ internal class FlowExtensionsTests {
 
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
-    fun `GIVEN a Loadable Flow that's Loading WHEN loading it into a LoadableScope THEN it loads`() { // ktlint-disable max-line-length
+    @Suppress("SpellCheckingInspection")
+    fun `GIVEN a Loadable Flow that's Loading WHEN sending its Loadables  into a LoadableScope THEN it loads`() { // ktlint-disable max-line-length
         runTest {
-            emptyLoadableFlow(loadableFlow<Serializable?>()::loadInto).test {
+            emptyLoadableFlow(loadableFlow<Serializable?>()::sendTo).test {
                 assertIs<Loadable.Loading<Serializable?>>(awaitItem())
             }
         }
@@ -229,9 +230,10 @@ internal class FlowExtensionsTests {
 
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
-    fun `GIVEN a Loadable Flow that's Loaded WHEN loading it into a LoadableScope THEN it loads the content`() { // ktlint-disable max-line-length
+    @Suppress("SpellCheckingInspection")
+    fun `GIVEN a Loadable Flow that's Loaded WHEN sending its Loadables into a LoadableScope THEN it loads the content`() { // ktlint-disable max-line-length
         runTest {
-            loadableFlow(loadableFlowOf(0)::loadInto).test {
+            loadableFlow(loadableFlowOf(0)::sendTo).test {
                 awaitItem()
                 assertEquals(Loadable.Loaded(0), awaitItem())
             }
@@ -240,11 +242,12 @@ internal class FlowExtensionsTests {
 
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
-    fun `GIVEN a Loadable Flow that's Failed WHEN loading it into a LoadableScope THEN it fails`() {
+    @Suppress("SpellCheckingInspection")
+    fun `GIVEN a Loadable Flow that's Failed WHEN sending its Loadables into a LoadableScope THEN it fails`() { // ktlint-disable max-line-length
         val error = Throwable()
         runTest {
             loadableFlow {
-                emptyLoadableFlow<Serializable?> { fail(error) }.loadInto(this)
+                emptyLoadableFlow<Serializable?> { fail(error) }.sendTo(this)
             }
                 .test {
                     awaitItem()


### PR DESCRIPTION
Adds [`Flow<Loadable<T>>.sendTo(LoadableScope): Unit`](https://github.com/jeanbarrossilva/loadable/blob/e8e373e91b7ceb29d4f21cfe14b0613486771bad/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/Flow.extensions.kt#L83).