### PR TITLE
Add `sendTo`-operator-analogue for non-`Loadable` `Flow`s

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -10,8 +10,8 @@ object Versions {
     val java = JavaVersion.VERSION_11
 
     object Loadable {
-        const val CODE = 8
-        const val NAME = "1.4.0"
+        const val CODE = 9
+        const val NAME = "1.4.1"
         const val SDK_COMPILE = 33
         const val SDK_MIN = 21
         const val SDK_TARGET = SDK_COMPILE

--- a/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
+++ b/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
@@ -258,6 +258,18 @@ internal class FlowExtensionsTests {
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `GIVEN a Flow WHEN loading it to the LoadableScope of a public Loadable-Flow-creator function THEN it's initially Loading once`() { // ktlint-disable max-line-length
+        runTest {
+            loadableFlow { flowOf(0).loadTo(this) }.test {
+                assertIs<Loadable.Loading<Int>>(awaitItem())
+                assertEquals(Loadable.Loaded(0), awaitItem())
+                awaitComplete()
+            }
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Suppress("CAST_NEVER_SUCCEEDS")
     @Test
     fun `GIVEN a Loadable ChannelFlow WHEN emitting from different scopes THEN it receives sent emissions`() { // ktlint-disable max-line-length


### PR DESCRIPTION
Adds [`Flow<T>.loadTo(LoadableScope)`](https://github.com/jeanbarrossilva/loadable/blob/f1ad0feaaf72d7e38c8ef95393e18598f0ff0b97/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/Flow.extensions.kt#L84), that turns the given [`Flow`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/-flow) into a [`Loadable`](https://github.com/jeanbarrossilva/loadable/blob/f1ad0feaaf72d7e38c8ef95393e18598f0ff0b97/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.kt) one and sends its emissions to the given [`LoadableScope`](https://github.com/jeanbarrossilva/loadable/blob/f1ad0feaaf72d7e38c8ef95393e18598f0ff0b97/loadable/src/main/java/com/jeanbarrossilva/loadable/LoadableScope.kt).