### PR TITLE
Add `Loadable`-to-`ListLoadable`-`Flow` converter function

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -10,8 +10,8 @@ object Versions {
     val java = JavaVersion.VERSION_11
 
     object Loadable {
-        const val CODE = 10
-        const val NAME = "1.5.0"
+        const val CODE = 11
+        const val NAME = "1.5.1"
         const val SDK_COMPILE = 33
         const val SDK_MIN = 21
         const val SDK_TARGET = SDK_COMPILE

--- a/loadable-list/build.gradle.kts
+++ b/loadable-list/build.gradle.kts
@@ -11,7 +11,11 @@ java {
 dependencies {
     api(project(":loadable"))
 
+    implementation(Libraries.KOTLINX_COROUTINES_CORE)
+
     testImplementation(Libraries.KOTLIN_TEST)
+    testImplementation(Libraries.KOTLINX_COROUTINES_TEST)
+    testImplementation(Libraries.TURBINE)
 }
 
 publishing {

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/flow/Flow.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/flow/Flow.extensions.kt
@@ -1,0 +1,41 @@
+package com.jeanbarrossilva.loadable.list.flow
+
+import com.jeanbarrossilva.loadable.Loadable
+import com.jeanbarrossilva.loadable.flow.loadable
+import com.jeanbarrossilva.loadable.list.ListLoadable
+import com.jeanbarrossilva.loadable.list.SerializableList
+import com.jeanbarrossilva.loadable.list.asListLoadable
+import java.io.Serializable
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filterNot
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+/** Returns a [Flow] containing only non-[loading][ListLoadable.Loading] values. **/
+fun <T : Serializable?> Flow<ListLoadable<T>>.filterNotLoading(): Flow<ListLoadable<T>> {
+    return filterNot {
+        it is ListLoadable.Loading
+    }
+}
+
+/**
+ * Maps each emission to a [ListLoadable] and emits an initial [loading][ListLoadable.Loading]
+ * value.
+ *
+ * @param coroutineScope [CoroutineScope] in which the [StateFlow] will be started and its
+ * [value][StateFlow.value] will be shared.
+ * @param sharingStarted Strategy for controlling when sharing starts and ends.
+ **/
+fun <T : Serializable?> Flow<SerializableList<T>>.listLoadable(
+    coroutineScope: CoroutineScope,
+    sharingStarted: SharingStarted
+): StateFlow<ListLoadable<T>> {
+    return loadable().map(Loadable<SerializableList<T>>::asListLoadable).stateIn(
+        coroutineScope,
+        sharingStarted,
+        initialValue = ListLoadable.Loading()
+    )
+}

--- a/loadable-list/src/test/java/com/jeanbarrossilva/loadable/list/flow/FlowExtensionsTests.kt
+++ b/loadable-list/src/test/java/com/jeanbarrossilva/loadable/list/flow/FlowExtensionsTests.kt
@@ -1,0 +1,89 @@
+package com.jeanbarrossilva.loadable.list.flow
+
+import app.cash.turbine.test
+import com.jeanbarrossilva.loadable.Loadable
+import com.jeanbarrossilva.loadable.flow.loadableFlow
+import com.jeanbarrossilva.loadable.list.ListLoadable
+import com.jeanbarrossilva.loadable.list.SerializableList
+import com.jeanbarrossilva.loadable.list.asListLoadable
+import com.jeanbarrossilva.loadable.list.emptySerializableList
+import com.jeanbarrossilva.loadable.list.serializableListOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.runTest
+
+internal class FlowExtensionsTests {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `GIVEN a ListLoadable Flow WHEN filtering by non-loading values THEN it's filtered`() {
+        runTest {
+            loadableFlow {
+                load(serializableListOf(1))
+                load()
+                load(serializableListOf(1, 2))
+                fail(Exception())
+            }
+                .map(Loadable<SerializableList<Int>>::asListLoadable)
+                .filterNotLoading()
+                .test {
+                    assertEquals(ListLoadable.Populated(serializableListOf(1)), awaitItem())
+                    assertEquals(ListLoadable.Populated(serializableListOf(1, 2)), awaitItem())
+                    assertIs<ListLoadable.Failed<Int>>(awaitItem())
+                    awaitComplete()
+                }
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `GIVEN a Flow WHEN converting it into a ListLoadable Flow THEN the initial value is loading`() { // ktlint-disable max-line-length
+        runTest {
+            flowOf(serializableListOf(1, 2, 3)).listLoadable(this, SharingStarted.Lazily).test {
+                assertIs<ListLoadable.Loading<Int>>(awaitItem())
+            }
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `GIVEN a Flow with an empty list WHEN converting it into a ListLoadable THEN it is empty`() { // ktlint-disable max-line-length
+        runTest {
+            flowOf(emptySerializableList<Int>())
+                .listLoadable(this, SharingStarted.Lazily)
+                .filterNotLoading()
+                .test { assertIs<ListLoadable.Empty<Int>>(awaitItem()) }
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `GIVEN a Flow with a populated list WHEN converting it into a ListLoadable THEN it is populated`() { // ktlint-disable max-line-length
+        runTest {
+            flowOf(serializableListOf(1, 2, 3))
+                .listLoadable(this, SharingStarted.Lazily)
+                .filterNotLoading()
+                .test {
+                    assertEquals(ListLoadable.Populated(serializableListOf(1, 2, 3)), awaitItem())
+                }
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `GIVEN a failed Flow WHEN converting it into a ListLoadable THEN it is failed`() { // ktlint-disable max-line-length
+        runTest {
+            loadableFlow<SerializableList<Int>> { fail(Exception()) }
+                .map(Loadable<SerializableList<Int>>::asListLoadable)
+                .filterNotLoading()
+                .test {
+                    assertIs<ListLoadable.Failed<Int>>(awaitItem())
+                    awaitComplete()
+                }
+        }
+    }
+}


### PR DESCRIPTION
Adds a function that converts a `Flow<Loadable<SerializableList<T>>>` into a `Flow<ListLoadable<T>>` (with `T : Serializable?`).