### PR TITLE
Rename to-`ListLoadable` converter functions to "toListLoadable"

### DIFF
--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/ListLoadable.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/ListLoadable.extensions.kt
@@ -40,16 +40,7 @@ inline fun <I : Serializable?, reified O : Serializable?> ListLoadable<I>.mapNot
     return when (this) {
         is ListLoadable.Loading -> ListLoadable.Loading()
         is ListLoadable.Empty -> ListLoadable.Empty()
-        is ListLoadable.Populated -> content.mapNotNull(transform).serialize<O>().asListLoadable()
+        is ListLoadable.Populated -> content.mapNotNull(transform).serialize<O>().toListLoadable()
         is ListLoadable.Failed -> ListLoadable.Failed(error)
-    }
-}
-
-/** Converts this [Loadable] into a [ListLoadable]. **/
-fun <T : Serializable?> Loadable<SerializableList<T>>.asListLoadable(): ListLoadable<T> {
-    return when (this) {
-        is Loadable.Loading -> ListLoadable.Loading()
-        is Loadable.Loaded -> content.asListLoadable()
-        is Loadable.Failed -> ListLoadable.Failed(error)
     }
 }

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/Loadable.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/Loadable.extensions.kt
@@ -1,0 +1,13 @@
+package com.jeanbarrossilva.loadable.list
+
+import com.jeanbarrossilva.loadable.Loadable
+import java.io.Serializable
+
+/** Converts this [Loadable] into a [ListLoadable]. **/
+fun <T : Serializable?> Loadable<SerializableList<T>>.toListLoadable(): ListLoadable<T> {
+    return when (this) {
+        is Loadable.Loading -> ListLoadable.Loading()
+        is Loadable.Loaded -> content.toListLoadable()
+        is Loadable.Failed -> ListLoadable.Failed(error)
+    }
+}

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/SerializableList.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/SerializableList.extensions.kt
@@ -3,7 +3,7 @@ package com.jeanbarrossilva.loadable.list
 import java.io.Serializable
 
 /** Converts this [SerializableList] into a [ListLoadable]. **/
-fun <T : Serializable?> SerializableList<T>.asListLoadable(): ListLoadable<T> {
+fun <T : Serializable?> SerializableList<T>.toListLoadable(): ListLoadable<T> {
     return if (isEmpty()) ListLoadable.Empty() else ListLoadable.Populated(this)
 }
 

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/flow/Flow.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/flow/Flow.extensions.kt
@@ -4,7 +4,7 @@ import com.jeanbarrossilva.loadable.Loadable
 import com.jeanbarrossilva.loadable.flow.loadable
 import com.jeanbarrossilva.loadable.list.ListLoadable
 import com.jeanbarrossilva.loadable.list.SerializableList
-import com.jeanbarrossilva.loadable.list.asListLoadable
+import com.jeanbarrossilva.loadable.list.toListLoadable
 import java.io.Serializable
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -33,7 +33,7 @@ fun <T : Serializable?> Flow<SerializableList<T>>.listLoadable(
     coroutineScope: CoroutineScope,
     sharingStarted: SharingStarted
 ): StateFlow<ListLoadable<T>> {
-    return loadable().map(Loadable<SerializableList<T>>::asListLoadable).stateIn(
+    return loadable().map(Loadable<SerializableList<T>>::toListLoadable).stateIn(
         coroutineScope,
         sharingStarted,
         initialValue = ListLoadable.Loading()

--- a/loadable-list/src/test/java/com/jeanbarrossilva/loadable/list/LoadableExtensionsTests.kt
+++ b/loadable-list/src/test/java/com/jeanbarrossilva/loadable/list/LoadableExtensionsTests.kt
@@ -1,0 +1,28 @@
+package com.jeanbarrossilva.loadable.list
+
+import com.jeanbarrossilva.loadable.Loadable
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+internal class LoadableExtensionsTests {
+    @Test
+    fun `GIVEN a loading Loadable WHEN converting it into a ListLoadable THEN it's loading`() {
+        assertIs<ListLoadable.Loading<SerializableList<Int>>>(
+            Loadable.Loading<SerializableList<Int>>().toListLoadable()
+        )
+    }
+
+    @Test
+    fun `GIVEN a loaded Loadable with an empty list WHEN converting it into a ListLoadable THEN it's empty`() { // ktlint-disable max-line-length
+        assertIs<ListLoadable.Empty<SerializableList<Int>>>(
+            Loadable.Loaded(emptySerializableList<Int>()).toListLoadable()
+        )
+    }
+
+    @Test
+    fun `GIVEN a loaded Loadable with a populated list WHEN converting it into a ListLoadable THEN it's populated`() { // ktlint-disable max-line-length
+        assertIs<ListLoadable.Populated<SerializableList<Int>>>(
+            Loadable.Loaded(serializableListOf(1, 2, 3)).toListLoadable()
+        )
+    }
+}

--- a/loadable-list/src/test/java/com/jeanbarrossilva/loadable/list/SerializableListExtensions.kt
+++ b/loadable-list/src/test/java/com/jeanbarrossilva/loadable/list/SerializableListExtensions.kt
@@ -1,33 +1,10 @@
 package com.jeanbarrossilva.loadable.list
 
-import com.jeanbarrossilva.loadable.Loadable
 import java.io.Serializable
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
-import kotlin.test.assertIs
 
 internal class SerializableListExtensions {
-    @Test
-    fun `GIVEN a loading Loadable WHEN converting it into a ListLoadable THEN it's loading`() {
-        assertIs<ListLoadable.Loading<SerializableList<Int>>>(
-            Loadable.Loading<SerializableList<Int>>().asListLoadable()
-        )
-    }
-
-    @Test
-    fun `GIVEN a loaded Loadable with an empty list WHEN converting it into a ListLoadable THEN it's empty`() { // ktlint-disable max-line-length
-        assertIs<ListLoadable.Empty<SerializableList<Int>>>(
-            Loadable.Loaded(emptySerializableList<Int>()).asListLoadable()
-        )
-    }
-
-    @Test
-    fun `GIVEN a loaded Loadable with a populated list WHEN converting it into a ListLoadable THEN it's populated`() { // ktlint-disable max-line-length
-        assertIs<ListLoadable.Populated<SerializableList<Int>>>(
-            Loadable.Loaded(serializableListOf(1, 2, 3)).asListLoadable()
-        )
-    }
-
     @Test
     fun `GIVEN a SerializableList created through emptySerializableList WHEN checking if it's empty THEN it is`() { // ktlint-disable max-line-length
         assertContentEquals(emptyList(), emptySerializableList<Serializable>())

--- a/loadable-list/src/test/java/com/jeanbarrossilva/loadable/list/flow/FlowExtensionsTests.kt
+++ b/loadable-list/src/test/java/com/jeanbarrossilva/loadable/list/flow/FlowExtensionsTests.kt
@@ -5,9 +5,9 @@ import com.jeanbarrossilva.loadable.Loadable
 import com.jeanbarrossilva.loadable.flow.loadableFlow
 import com.jeanbarrossilva.loadable.list.ListLoadable
 import com.jeanbarrossilva.loadable.list.SerializableList
-import com.jeanbarrossilva.loadable.list.asListLoadable
 import com.jeanbarrossilva.loadable.list.emptySerializableList
 import com.jeanbarrossilva.loadable.list.serializableListOf
+import com.jeanbarrossilva.loadable.list.toListLoadable
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -28,7 +28,7 @@ internal class FlowExtensionsTests {
                 load(serializableListOf(1, 2))
                 fail(Exception())
             }
-                .map(Loadable<SerializableList<Int>>::asListLoadable)
+                .map(Loadable<SerializableList<Int>>::toListLoadable)
                 .filterNotLoading()
                 .test {
                     assertEquals(ListLoadable.Populated(serializableListOf(1)), awaitItem())
@@ -78,7 +78,7 @@ internal class FlowExtensionsTests {
     fun `GIVEN a failed Flow WHEN converting it into a ListLoadable THEN it is failed`() { // ktlint-disable max-line-length
         runTest {
             loadableFlow<SerializableList<Int>> { fail(Exception()) }
-                .map(Loadable<SerializableList<Int>>::asListLoadable)
+                .map(Loadable<SerializableList<Int>>::toListLoadable)
                 .filterNotLoading()
                 .test {
                     assertIs<ListLoadable.Failed<Int>>(awaitItem())


### PR DESCRIPTION
There are a few online resources that explain the preference of "as" over "to" and vice-versa when it comes to naming converter functions.

I think it's a lot confusing though. So I'll stick to how I've been naming those throughout the library,