### PR TITLE
Test `SerializableList`-to-`ListLoadable` converter function

### DIFF
--- a/loadable-list/src/test/java/com/jeanbarrossilva/loadable/list/SerializableListExtensions.kt
+++ b/loadable-list/src/test/java/com/jeanbarrossilva/loadable/list/SerializableListExtensions.kt
@@ -3,8 +3,23 @@ package com.jeanbarrossilva.loadable.list
 import java.io.Serializable
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
 
 internal class SerializableListExtensions {
+    @Test
+    fun `GIVEN an empty SerializableList WHEN converting it into a ListLoadable THEN it's empty`() {
+        assertIs<ListLoadable.Empty<String>>(emptySerializableList<String>().toListLoadable())
+    }
+
+    @Test
+    fun `GIVEN a populated SerializableList WHEN converting it into a ListLoadable THEN it's populated`() { // ktlint-disable max-line-length
+        assertEquals(
+            ListLoadable.Populated(serializableListOf("A", "B", "C")),
+            serializableListOf("A", "B", "C").toListLoadable()
+        )
+    }
+
     @Test
     fun `GIVEN a SerializableList created through emptySerializableList WHEN checking if it's empty THEN it is`() { // ktlint-disable max-line-length
         assertContentEquals(emptyList(), emptySerializableList<Serializable>())


### PR DESCRIPTION
Adds the missing tests for the function that converts a [`SerializableList`](https://github.com/jeanbarrossilva/loadable/blob/11efa421ac31ca991022ef5e62d6c8be362f30e9/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/SerializableList.kt) into a [`ListLoadable`](https://github.com/jeanbarrossilva/loadable/blob/11efa421ac31ca991022ef5e62d6c8be362f30e9/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/ListLoadable.kt).