### PR TITLE
Export `:loadable-list`'s sources and Javadoc

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -10,8 +10,8 @@ object Versions {
     val java = JavaVersion.VERSION_11
 
     object Loadable {
-        const val CODE = 11
-        const val NAME = "1.5.1"
+        const val CODE = 12
+        const val NAME = "1.5.2"
         const val SDK_COMPILE = 33
         const val SDK_MIN = 21
         const val SDK_TARGET = SDK_COMPILE

--- a/loadable-list/build.gradle.kts
+++ b/loadable-list/build.gradle.kts
@@ -6,6 +6,10 @@ plugins {
 
 java {
     sourceCompatibility = Versions.java
+    targetCompatibility = Versions.java
+
+    withJavadocJar()
+    withSourcesJar()
 }
 
 dependencies {


### PR DESCRIPTION
Exports the JARs containing the source and the documentation of [`:loadable-list`](https://github.com/jeanbarrossilva/loadable/tree/6ede547657d67864298c5b49cc4488cdc2075024/loadable-list).