### PR TITLE
Export `:loadable-placeholder`'s sources and Javadoc

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -15,8 +15,8 @@ object Versions {
     val java = JavaVersion.VERSION_11
 
     object Loadable {
-        const val CODE = 13
-        const val NAME = "1.6.0"
+        const val CODE = 14
+        const val NAME = "1.6.1"
         const val SDK_COMPILE = 33
         const val SDK_MIN = 21
         const val SDK_TARGET = SDK_COMPILE

--- a/loadable-placeholder-test/build.gradle.kts
+++ b/loadable-placeholder-test/build.gradle.kts
@@ -14,6 +14,13 @@ android {
         consumerProguardFiles("consumer-rules.pro")
     }
 
+    publishing {
+        singleVariant(Variants.RELEASE) {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
+
     buildTypes {
         release {
             @Suppress("UnstableApiUsage")

--- a/loadable-placeholder/build.gradle.kts
+++ b/loadable-placeholder/build.gradle.kts
@@ -14,6 +14,13 @@ android {
         consumerProguardFiles("consumer-rules.pro")
     }
 
+    publishing {
+        singleVariant(Variants.RELEASE) {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
+
     buildTypes {
         release {
             @Suppress("UnstableApiUsage")


### PR DESCRIPTION
Exports the JARs containing the source and the documentation of [`:loadable-placeholder`](https://github.com/jeanbarrossilva/loadable/tree/36bbe088f65928d81551a3c586604ff95f695462/loadable-placeholder) and [`:loadable-placeholder-test`](https://github.com/jeanbarrossilva/loadable/tree/36bbe088f65928d81551a3c586604ff95f695462/loadable-placeholder-test).