### PR TITLE
Fix `TextualPlaceholder` with fixed, constrained size

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -15,8 +15,8 @@ object Versions {
     val java = JavaVersion.VERSION_11
 
     object Loadable {
-        const val CODE = 15
-        const val NAME = "1.6.2"
+        const val CODE = 16
+        const val NAME = "1.6.3"
         const val SDK_COMPILE = 33
         const val SDK_MIN = 21
         const val SDK_TARGET = SDK_COMPILE

--- a/loadable-placeholder/src/androidTest/java/com/jeanbarrossilva/loadable/placeholder/ModifierExtensionsTests.kt
+++ b/loadable-placeholder/src/androidTest/java/com/jeanbarrossilva/loadable/placeholder/ModifierExtensionsTests.kt
@@ -1,0 +1,41 @@
+package com.jeanbarrossilva.loadable.placeholder
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.state.ToggleableState
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.jeanbarrossilva.loadable.placeholder.test.onPlaceholder
+import com.jeanbarrossilva.loadable.placeholder.test.tagAsPlaceholder
+import org.junit.Rule
+import org.junit.Test
+
+internal class ModifierExtensionsTests {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun isNotTransformedWhenConditionPassedToIfIsFalse() {
+        composeRule.setContent { Placeholder(Modifier.`if`(false, Modifier::tagAsPlaceholder)) }
+        composeRule.onPlaceholder().assertDoesNotExist()
+    }
+
+    @Test
+    fun isTransformedWhenConditionPassedToIfIsTrue() {
+        composeRule.setContent { Placeholder(Modifier.`if`(true, Modifier::tagAsPlaceholder)) }
+        composeRule.onPlaceholder().assertExists()
+    }
+
+    @Test
+    fun transformIsAppliedToReceiverModifierOfIf() {
+        composeRule.setContent {
+            Placeholder(
+                Modifier
+                    .semantics { set(SemanticsProperties.ToggleableState, ToggleableState.On) }
+                    .`if`(true, Modifier::tagAsPlaceholder)
+            )
+        }
+        composeRule.onPlaceholder().assertIsOn()
+    }
+}

--- a/loadable-placeholder/src/androidTest/java/com/jeanbarrossilva/loadable/placeholder/TextualPlaceholderTests.kt
+++ b/loadable-placeholder/src/androidTest/java/com/jeanbarrossilva/loadable/placeholder/TextualPlaceholderTests.kt
@@ -2,6 +2,7 @@ package com.jeanbarrossilva.loadable.placeholder
 
 import androidx.compose.material3.Text
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertHeightIsAtLeast
 import androidx.compose.ui.test.assertWidthIsEqualTo
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.text.TextStyle
@@ -33,5 +34,21 @@ internal class TextualPlaceholderTests {
             }
         }
         composeRule.onPlaceholder().assertWidthIsEqualTo(screenWidth)
+    }
+
+    @Test
+    fun heightIsNotConstrainedIfItIsLoaded() {
+        val displayMetrics =
+            InstrumentationRegistry.getInstrumentation().context.resources.displayMetrics
+        composeRule.setContent {
+            MediumTextualPlaceholder(
+                Loadable.Loaded("🙃".repeat(displayMetrics.heightPixels)),
+                Modifier.tagAsPlaceholder(),
+                TextStyle(fontSize = 14.sp)
+            ) {
+                Text(this)
+            }
+        }
+        composeRule.onPlaceholder().assertHeightIsAtLeast(24.dp)
     }
 }

--- a/loadable-placeholder/src/androidTest/java/com/jeanbarrossilva/loadable/placeholder/TextualPlaceholderTests.kt
+++ b/loadable-placeholder/src/androidTest/java/com/jeanbarrossilva/loadable/placeholder/TextualPlaceholderTests.kt
@@ -1,0 +1,37 @@
+package com.jeanbarrossilva.loadable.placeholder
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertWidthIsEqualTo
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.test.platform.app.InstrumentationRegistry
+import com.jeanbarrossilva.loadable.Loadable
+import com.jeanbarrossilva.loadable.placeholder.test.onPlaceholder
+import com.jeanbarrossilva.loadable.placeholder.test.tagAsPlaceholder
+import org.junit.Rule
+import org.junit.Test
+
+internal class TextualPlaceholderTests {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun widthIsNotConstrainedIfItIsLoaded() {
+        val resources = InstrumentationRegistry.getInstrumentation().context.resources
+        val screenWidth = resources.configuration.screenWidthDp.dp
+        val screenWidthInPx = resources.displayMetrics.widthPixels
+        composeRule.setContent {
+            MediumTextualPlaceholder(
+                Loadable.Loaded("🙂".repeat(screenWidthInPx)),
+                Modifier.tagAsPlaceholder(),
+                TextStyle(fontSize = 14.sp)
+            ) {
+                Text(this)
+            }
+        }
+        composeRule.onPlaceholder().assertWidthIsEqualTo(screenWidth)
+    }
+}

--- a/loadable-placeholder/src/main/java/com/jeanbarrossilva/loadable/placeholder/Modifier.extensions.kt
+++ b/loadable-placeholder/src/main/java/com/jeanbarrossilva/loadable/placeholder/Modifier.extensions.kt
@@ -1,0 +1,15 @@
+package com.jeanbarrossilva.loadable.placeholder
+
+import androidx.compose.ui.Modifier
+
+/**
+ * Returns the result of the given [transform] if the [condition] is `true`; otherwise, returns the
+ * receiver [Modifier].
+ *
+ * @param condition Determines whether the result of [transform] will get returned.
+ * @param transform Transformation to be made to this [Modifier].
+ **/
+internal fun Modifier.`if`(condition: Boolean, transform: Modifier.() -> Modifier):
+    Modifier {
+    return if (condition) transform() else this
+}

--- a/loadable-placeholder/src/main/java/com/jeanbarrossilva/loadable/placeholder/Modifier.extensions.kt
+++ b/loadable-placeholder/src/main/java/com/jeanbarrossilva/loadable/placeholder/Modifier.extensions.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.Modifier
  * @param condition Determines whether the result of [transform] will get returned.
  * @param transform Transformation to be made to this [Modifier].
  **/
-internal fun Modifier.`if`(condition: Boolean, transform: Modifier.() -> Modifier):
-    Modifier {
+internal fun Modifier.`if`(condition: Boolean, transform: Modifier.() -> Modifier): Modifier {
     return if (condition) transform() else this
 }

--- a/loadable-placeholder/src/main/java/com/jeanbarrossilva/loadable/placeholder/Placeholder.kt
+++ b/loadable-placeholder/src/main/java/com/jeanbarrossilva/loadable/placeholder/Placeholder.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
@@ -24,6 +25,7 @@ import com.jeanbarrossilva.loadable.Loadable
 import com.jeanbarrossilva.loadable.ifLoaded
 import com.jeanbarrossilva.loadable.placeholder.test.Loading
 import java.io.Serializable
+import loadable
 
 /** Default values of a [Placeholder]. **/
 object PlaceholderDefaults {
@@ -285,8 +287,11 @@ private fun TextualPlaceholder(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit = { }
 ) {
-    val height = with(LocalDensity.current) {
-        style.fontSize.toDp()
+    val density = LocalDensity.current
+    val height = remember(style, density) {
+        with(density) {
+            style.fontSize.toDp()
+        }
     }
 
     Placeholder(

--- a/loadable-placeholder/src/main/java/com/jeanbarrossilva/loadable/placeholder/Placeholder.kt
+++ b/loadable-placeholder/src/main/java/com/jeanbarrossilva/loadable/placeholder/Placeholder.kt
@@ -291,8 +291,8 @@ private fun TextualPlaceholder(
 
     Placeholder(
         modifier
-            .requiredHeight(height)
-            .fillMaxWidth(fraction),
+            .`if`(isVisible) { requiredHeight(height) }
+            .`if`(isVisible) { fillMaxWidth(fraction) },
         isVisible,
         shapeFor(style),
         color,

--- a/loadable-placeholder/src/main/java/com/jeanbarrossilva/loadable/placeholder/Placeholder.kt
+++ b/loadable-placeholder/src/main/java/com/jeanbarrossilva/loadable/placeholder/Placeholder.kt
@@ -25,7 +25,6 @@ import com.jeanbarrossilva.loadable.Loadable
 import com.jeanbarrossilva.loadable.ifLoaded
 import com.jeanbarrossilva.loadable.placeholder.test.Loading
 import java.io.Serializable
-import loadable
 
 /** Default values of a [Placeholder]. **/
 object PlaceholderDefaults {


### PR DESCRIPTION
Loaded variations of [`TextualPlaceholder`](https://github.com/jeanbarrossilva/loadable/blob/e1d3805d3ee4efccf96f43e5e4f3e2e267139dcb/loadable-placeholder/src/main/java/com/jeanbarrossilva/loadable/placeholder/Placeholder.kt#L280) were constrained to their "loading" width.