### PR TITLE
Set given `TextualPlaceholder` `TextStyle` as the current local one

### DIFF
--- a/loadable-placeholder/src/androidTest/java/com/jeanbarrossilva/loadable/placeholder/TextualPlaceholderTests.kt
+++ b/loadable-placeholder/src/androidTest/java/com/jeanbarrossilva/loadable/placeholder/TextualPlaceholderTests.kt
@@ -1,5 +1,7 @@
 package com.jeanbarrossilva.loadable.placeholder
 
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertHeightIsAtLeast
@@ -12,6 +14,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.jeanbarrossilva.loadable.Loadable
 import com.jeanbarrossilva.loadable.placeholder.test.onPlaceholder
 import com.jeanbarrossilva.loadable.placeholder.test.tagAsPlaceholder
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 
@@ -50,5 +53,17 @@ internal class TextualPlaceholderTests {
             }
         }
         composeRule.onPlaceholder().assertHeightIsAtLeast(24.dp)
+    }
+
+    @Test
+    fun passedTextStyleIsSetAsTheLocalOne() {
+        composeRule.setContent {
+            MediumTextualPlaceholder(
+                Loadable.Loaded("🤌🏽"),
+                style = MaterialTheme.typography.headlineLarge
+            ) {
+                assertEquals(MaterialTheme.typography.headlineLarge, LocalTextStyle.current)
+            }
+        }
     }
 }

--- a/loadable-placeholder/src/main/java/com/jeanbarrossilva/loadable/placeholder/Placeholder.kt
+++ b/loadable-placeholder/src/main/java/com/jeanbarrossilva/loadable/placeholder/Placeholder.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -299,9 +300,10 @@ private fun TextualPlaceholder(
             .`if`(isVisible) { fillMaxWidth(fraction) },
         isVisible,
         shapeFor(style),
-        color,
-        content
-    )
+        color
+    ) {
+        ProvideTextStyle(style, content)
+    }
 }
 
 /**


### PR DESCRIPTION
Makes so that the [`TextStyle`](https://developer.android.com/reference/kotlin/androidx/compose/ui/text/TextStyle) specified to a [`TextualPlaceholder`](https://github.com/jeanbarrossilva/loadable/blob/15e0a25f24dd1159ddf75d332692c33e590c55e9/loadable-placeholder/src/main/java/com/jeanbarrossilva/loadable/placeholder/Placeholder.kt#L282) is the one that's used by default by text-based [Composable](https://developer.android.com/reference/kotlin/androidx/compose/runtime/Composable)s.

Example:

```kotlin
MediumTextualPlaceholder(
    Loadable.Loaded("Hello, world!"),
    style = MaterialTheme.typography.bodyMedium
) {
    /*
     * Inside this Composable content's scope, LocalTextStyle.current returns the
     * MaterialTheme.typography.bodyMedium that's been specified above.
     */

    // 👇🏽 Automatically defaults its TextStyle to LocalTextStyle.current.
    Text(this)
}
```