### PR TITLE
Provide `BoxScope` to `Placeholder` content

### DIFF
--- a/loadable-placeholder/src/main/java/com/jeanbarrossilva/loadable/placeholder/Placeholder.kt
+++ b/loadable-placeholder/src/main/java/com/jeanbarrossilva/loadable/placeholder/Placeholder.kt
@@ -1,6 +1,7 @@
 package com.jeanbarrossilva.loadable.placeholder
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.size
@@ -77,7 +78,7 @@ fun Placeholder(
     isLoading: Boolean = true,
     shape: Shape = PlaceholderDefaults.shape,
     color: Color = PlaceholderDefaults.color,
-    content: @Composable () -> Unit = { }
+    content: @Composable BoxScope.() -> Unit = { }
 ) {
     Box(
         modifier


### PR DESCRIPTION
Provides the [`BoxScope`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/BoxScope) of the underlying [`Box`](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/package-summary#Box(androidx.compose.ui.Modifier,androidx.compose.ui.Alignment,kotlin.Boolean,kotlin.Function1)) of a [`Placeholder`](https://github.com/jeanbarrossilva/loadable/blob/41aa125bb5cdd2beeb71aabfca8fa51e69a3e929/loadable-placeholder/src/main/java/com/jeanbarrossilva/loadable/placeholder/Placeholder.kt#L76) to its content.