### PR TITLE
Rename `serialize` extension function to "toSerializableList"

### DIFF
--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/Array.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/Array.extensions.kt
@@ -1,6 +1,6 @@
 package com.jeanbarrossilva.loadable.list
 
 /** Converts this [Array] into a [SerializableList]. **/
-fun <T> Array<out T>.serialize(): SerializableList<T> {
+fun <T> Array<out T>.toSerializableList(): SerializableList<T> {
     return serializableListOf(*this)
 }

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/Collection.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/Collection.extensions.kt
@@ -1,6 +1,6 @@
 package com.jeanbarrossilva.loadable.list
 
 /** Converts this [Collection] it into a [SerializableList]. **/
-inline fun <reified T> Collection<T>.serialize(): SerializableList<T> {
-    return toTypedArray().serialize()
+inline fun <reified T> Collection<T>.toSerializableList(): SerializableList<T> {
+    return toTypedArray().toSerializableList()
 }

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/ListLoadable.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/ListLoadable.extensions.kt
@@ -38,9 +38,13 @@ inline fun <I : Serializable?, reified O : Serializable?> ListLoadable<I>.mapNot
     transform: (I) -> O?
 ): ListLoadable<O> {
     return when (this) {
-        is ListLoadable.Loading -> ListLoadable.Loading()
-        is ListLoadable.Empty -> ListLoadable.Empty()
-        is ListLoadable.Populated -> content.mapNotNull(transform).serialize<O>().toListLoadable()
-        is ListLoadable.Failed -> ListLoadable.Failed(error)
+        is ListLoadable.Loading ->
+            ListLoadable.Loading()
+        is ListLoadable.Empty ->
+            ListLoadable.Empty()
+        is ListLoadable.Populated ->
+            content.mapNotNull(transform).toSerializableList<O>().toListLoadable()
+        is ListLoadable.Failed ->
+            ListLoadable.Failed(error)
     }
 }

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/ListLoadableScope.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/ListLoadableScope.kt
@@ -14,10 +14,10 @@ abstract class ListLoadableScope<T : Serializable?> internal constructor() {
      *
      * @param content [Array] to be converted into a [SerializableList] and sent either as a
      * [ListLoadable.Empty] or a [ListLoadable.Populated].
-     * @see Array.serialize
+     * @see Array.toSerializableList
      **/
     suspend fun load(vararg content: T) {
-        load(content.serialize())
+        load(content.toSerializableList())
     }
 
     /**

--- a/loadable-list/src/test/java/com/jeanbarrossilva/loadable/list/ArrayExtensionsTests.kt
+++ b/loadable-list/src/test/java/com/jeanbarrossilva/loadable/list/ArrayExtensionsTests.kt
@@ -5,7 +5,7 @@ import kotlin.test.assertEquals
 
 internal class ArrayExtensionsTests {
     @Test
-    fun `GIVEN an Array WHEN serializing it THEN it's a SerializableList with all of its previous elements`() { // ktlint-disable max-line-length
-        assertEquals(serializableListOf(1, 2, 3), arrayOf(1, 2, 3).serialize())
+    fun `GIVEN an Array WHEN converting it into a SerializableList THEN it preserves its elements`() { // ktlint-disable max-line-length
+        assertEquals(serializableListOf(1, 2, 3), arrayOf(1, 2, 3).toSerializableList())
     }
 }

--- a/loadable-list/src/test/java/com/jeanbarrossilva/loadable/list/CollectionExtensionsTests.kt
+++ b/loadable-list/src/test/java/com/jeanbarrossilva/loadable/list/CollectionExtensionsTests.kt
@@ -5,7 +5,7 @@ import kotlin.test.assertEquals
 
 internal class CollectionExtensionsTests {
     @Test
-    fun `GIVEN a Collection WHEN serializing it THEN it's a SerializableList with all of its previous elements`() { // ktlint-disable max-line-length
-        assertEquals(serializableListOf(1, 2, 3), listOf(1, 2, 3).serialize())
+    fun `GIVEN a Collection WHEN converting it into a SerializableList THEN it preserves its previous elements`() { // ktlint-disable max-line-length
+        assertEquals(serializableListOf(1, 2, 3), listOf(1, 2, 3).toSerializableList())
     }
 }


### PR DESCRIPTION
Renames [`<T> Array<T>.serialize`](https://github.com/jeanbarrossilva/loadable/blob/85294931c687e8c1fd9254020478516ad72fe950/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/Array.extensions.kt#L4) and [`<T> Collection<T>.serialize`](https://github.com/jeanbarrossilva/loadable/blob/85294931c687e8c1fd9254020478516ad72fe950/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/Collection.extensions.kt#L4) to "toSerializableList".