### PR TITLE
Fix misinformation on `Flow<Loadable<out Serializable?>>.innerMap`'s documentation

### DIFF
--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/Flow.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/Flow.extensions.kt
@@ -32,9 +32,10 @@ fun <T : Serializable?> Flow<Loadable<T>>.filterIsLoaded(): Flow<Loadable.Loaded
 }
 
 /**
- * Maps each emitted [Loadable] with the given [transform].
+ * Maps each emitted [loaded][Loadable.Loaded] [Loadable]'s [content][Loadable.Loaded.content] with
+ * the given [transform].
  *
- * @param transform Transformation to be done to the [Loadable]s.
+ * @param transform Transformation to be done to the [content][Loadable.Loaded.content].
  **/
 fun <I : Serializable?, O : Serializable?> Flow<Loadable<I>>.innerMap(transform: suspend (I) -> O):
     Flow<Loadable<O>> {


### PR DESCRIPTION
The documentation is misleading:

> Maps each emitted [Loadable] with the given [transform].

It doesn't; it transforms the content of loaded [`Loadable`](https://github.com/jeanbarrossilva/loadable/blob/61a017cddcb5d2241960c38f514f2df4bbd63b16/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.kt)s, not the [`Loadable`](https://github.com/jeanbarrossilva/loadable/blob/61a017cddcb5d2241960c38f514f2df4bbd63b16/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.kt)s themselves.