### PR TITLE
Change `CoroutineScope`-based `Loadable`-`Flow`-creator functions return type to `MutableStateFlow`

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -16,8 +16,8 @@ object Versions {
     val java = JavaVersion.VERSION_11
 
     object Loadable {
-        const val CODE = 18
-        const val NAME = "1.6.5"
+        const val CODE = 19
+        const val NAME = "1.6.6"
         const val SDK_COMPILE = 33
         const val SDK_MIN = 21
         const val SDK_TARGET = SDK_COMPILE

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/MutableStateFlow.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/MutableStateFlow.extensions.kt
@@ -1,8 +1,50 @@
 package com.jeanbarrossilva.loadable.flow
 
 import com.jeanbarrossilva.loadable.Loadable
+import com.jeanbarrossilva.loadable.LoadableScope
 import java.io.Serializable
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.launch
+
+/**
+ * Maps each emission made to this [Flow] to a [Loadable].
+ *
+ * Emits, initially, [Loadable.Loading], [Loadable.Loaded] for each value and [Loadable.Failed] for
+ * thrown [Throwable]s.
+ *
+ * @param coroutineScope [CoroutineScope] in which the resulting [MutableStateFlow] will be started
+ * and its [value][MutableStateFlow.value] will be shared.
+ **/
+fun <T : Serializable?> Flow<T>.loadable(coroutineScope: CoroutineScope):
+    MutableStateFlow<Loadable<T>> {
+    return loadableFlow(coroutineScope) {
+        collect(::load)
+    }
+}
+
+/**
+ * Creates a [MutableStateFlow] of [Loadable]s that's started and shared in the [coroutineScope] and
+ * emits them through [load] with a [LoadableScope]. Its initial [value][MutableStateFlow.value] is
+ * [loading][Loadable.Loading].
+ *
+ * @param coroutineScope [CoroutineScope] in which the resulting [MutableStateFlow] will be started
+ * and its [value][MutableStateFlow.value] will be shared.
+ * @param load Operations to be made on the [LoadableScope] responsible for emitting [Loadable]s
+ * sent to it to the created [MutableStateFlow].
+ **/
+fun <T : Serializable?> loadableFlow(
+    coroutineScope: CoroutineScope,
+    load: suspend LoadableScope<T>.() -> Unit
+): MutableStateFlow<Loadable<T>> {
+    return loadableFlow<T>().apply {
+        coroutineScope.launch {
+            emitAll(emptyLoadableFlow(load))
+        }
+    }
+}
 
 /** Creates a [MutableStateFlow] with a [Loadable.Loading] as its initial value. **/
 fun <T : Serializable?> loadableFlow(): MutableStateFlow<Loadable<T>> {

--- a/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
+++ b/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
@@ -51,15 +51,6 @@ internal class FlowExtensionsTests {
     }
 
     @Test
-    fun `GIVEN a Loadable Flow with an initial content WHEN collecting it THEN the value that's emitted first is a Loaded one`() { // ktlint-disable max-line-length
-        runTest {
-            loadableFlowOf(0).test {
-                assertEquals(Loadable.Loaded(0), awaitItem())
-            }
-        }
-    }
-
-    @Test
     fun `GIVEN a Loadable Flow WHEN filtering Failed values THEN they're all emitted`() {
         runTest {
             flow {
@@ -158,9 +149,10 @@ internal class FlowExtensionsTests {
     @Test
     fun `GIVEN a Flow WHEN converting it into a Loadable one in a CoroutineScope THEN Loading is only emitted once as an initial value`() { // ktlint-disable max-line-length
         runTest {
-            flowOf(0).loadable(this).test {
+            flowOf(0).loadable().test {
                 assertIs<Loadable.Loading<Int>>(awaitItem())
                 assertEquals(Loadable.Loaded(0), awaitItem())
+                awaitComplete()
             }
         }
     }

--- a/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/MutableStateFlowExtensionsTests.kt
+++ b/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/MutableStateFlowExtensionsTests.kt
@@ -1,0 +1,18 @@
+package com.jeanbarrossilva.loadable.flow
+
+import app.cash.turbine.test
+import com.jeanbarrossilva.loadable.Loadable
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+
+internal class MutableStateFlowExtensionsTests {
+    @Test
+    fun `GIVEN a Loadable Flow with an initial content WHEN collecting it THEN the value that's emitted first is a Loaded one`() { // ktlint-disable max-line-length
+        runTest {
+            loadableFlowOf(0).test {
+                Assert.assertEquals(Loadable.Loaded(0), awaitItem())
+            }
+        }
+    }
+}


### PR DESCRIPTION
Makes [`Loadable`](https://github.com/jeanbarrossilva/loadable/blob/e92f2a66bb4ec81c8a6183025f6366147e63802f/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.kt)-[`Flow`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/-flow)-creator functions return a [`MutableStateFlow`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/-mutable-state-flow) instead of a [`StateFlow`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/-state-flow).