### PR TITLE
Enforce serializability at runtime

### DIFF
--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/Array.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/Array.extensions.kt
@@ -1,6 +1,13 @@
 package com.jeanbarrossilva.loadable.list
 
-/** Converts this [Array] into a [SerializableList]. **/
+import java.io.NotSerializableException
+
+/**
+ * Converts this [Array] into a [SerializableList].
+ *
+ * @throws NotSerializableException If any of the elements cannot be serialized.
+ **/
+@Throws(NotSerializableException::class)
 fun <T> Array<out T>.toSerializableList(): SerializableList<T> {
     return serializableListOf(*this)
 }

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/Collection.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/Collection.extensions.kt
@@ -1,6 +1,13 @@
 package com.jeanbarrossilva.loadable.list
 
-/** Converts this [Collection] it into a [SerializableList]. **/
+import java.io.NotSerializableException
+
+/**
+ * Converts this [Collection] it into a [SerializableList].
+ *
+ * @throws NotSerializableException If any of the elements cannot be serialized.
+ **/
+@Throws(NotSerializableException::class)
 inline fun <reified T> Collection<T>.toSerializableList(): SerializableList<T> {
     return toTypedArray().toSerializableList()
 }

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/ListLoadable.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/ListLoadable.extensions.kt
@@ -2,7 +2,6 @@ package com.jeanbarrossilva.loadable.list
 
 import com.jeanbarrossilva.loadable.Loadable
 import com.jeanbarrossilva.loadable.map
-import java.io.Serializable
 
 /**
  * Returns the first element of the [SerializableList] to match the given [predicate], wrapped by a
@@ -10,7 +9,7 @@ import java.io.Serializable
  *
  * @param predicate Condition to which the element to be found should conform.
  **/
-fun <T : Serializable?> ListLoadable<T>.find(predicate: (T) -> Boolean): Loadable<T?> {
+fun <T> ListLoadable<T>.find(predicate: (T) -> Boolean): Loadable<T?> {
     return toLoadable().map { content ->
         content.find(predicate)
     }
@@ -22,7 +21,7 @@ fun <T : Serializable?> ListLoadable<T>.find(predicate: (T) -> Boolean): Loadabl
  *
  * @param transform Transformation to be made to the [SerializableList].
  **/
-fun <I : Serializable?, O> ListLoadable<I>.ifPopulated(transform: SerializableList<I>.() -> O): O? {
+fun <I, O> ListLoadable<I>.ifPopulated(transform: SerializableList<I>.() -> O): O? {
     return if (this is ListLoadable.Populated) content.transform() else null
 }
 
@@ -34,9 +33,7 @@ fun <I : Serializable?, O> ListLoadable<I>.ifPopulated(transform: SerializableLi
  * @param transform Transformation to be made to the elements of the
  * [populated][ListLoadable.Populated] [SerializableList].
  **/
-inline fun <I : Serializable?, reified O : Serializable?> ListLoadable<I>.mapNotNull(
-    transform: (I) -> O?
-): ListLoadable<O> {
+inline fun <I, reified O> ListLoadable<I>.mapNotNull(transform: (I) -> O?): ListLoadable<O> {
     return when (this) {
         is ListLoadable.Loading ->
             ListLoadable.Loading()

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/ListLoadable.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/ListLoadable.kt
@@ -1,18 +1,17 @@
 package com.jeanbarrossilva.loadable.list
 
 import com.jeanbarrossilva.loadable.Loadable
-import java.io.Serializable
 
 /**
  * [Loadable]-like structure for representing different stages of an asynchronously-loaded
  * [SerializableList], as well as its "population" state.
  **/
-sealed interface ListLoadable<T : Serializable?> {
+sealed interface ListLoadable<T> {
     /** Whether this [ListLoadable] has been successfully loaded. **/
     val isLoaded: Boolean
 
     /** Stage in which the [SerializableList] is loading. **/
-    class Loading<T : Serializable?> : ListLoadable<T> {
+    class Loading<T> : ListLoadable<T> {
         override val isLoaded = false
 
         override fun toLoadable(): Loadable<SerializableList<T>> {
@@ -21,7 +20,7 @@ sealed interface ListLoadable<T : Serializable?> {
     }
 
     /** Stage in which the [SerializableList] has been loaded but it's empty. **/
-    class Empty<T : Serializable?> : ListLoadable<T> {
+    class Empty<T> : ListLoadable<T> {
         override val isLoaded = true
 
         override fun toLoadable(): Loadable<SerializableList<T>> {
@@ -37,7 +36,7 @@ sealed interface ListLoadable<T : Serializable?> {
      * @throws IllegalArgumentException If [content] is empty.
      */
     @JvmInline
-    value class Populated<T : Serializable?>(val content: SerializableList<T>) : ListLoadable<T> {
+    value class Populated<T>(val content: SerializableList<T>) : ListLoadable<T> {
         override val isLoaded
             get() = true
 
@@ -58,7 +57,7 @@ sealed interface ListLoadable<T : Serializable?> {
      * @param error [Throwable] that's been thrown while trying to load the [SerializableList].
      **/
     @JvmInline
-    value class Failed<T : Serializable?>(val error: Throwable) : ListLoadable<T> {
+    value class Failed<T>(val error: Throwable) : ListLoadable<T> {
         override val isLoaded
             get() = false
 

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/ListLoadableScope.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/ListLoadableScope.kt
@@ -1,9 +1,7 @@
 package com.jeanbarrossilva.loadable.list
 
-import java.io.Serializable
-
 /** Scope through which [ListLoadable]s are sent. **/
-abstract class ListLoadableScope<T : Serializable?> internal constructor() {
+abstract class ListLoadableScope<T> internal constructor() {
     /** Sends a [ListLoadable.Loading]. **/
     suspend fun load() {
         send(ListLoadable.Loading())

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/ListLoadableScope.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/ListLoadableScope.kt
@@ -1,5 +1,7 @@
 package com.jeanbarrossilva.loadable.list
 
+import java.io.NotSerializableException
+
 /** Scope through which [ListLoadable]s are sent. **/
 abstract class ListLoadableScope<T> internal constructor() {
     /** Sends a [ListLoadable.Loading]. **/
@@ -13,7 +15,9 @@ abstract class ListLoadableScope<T> internal constructor() {
      * @param content [Array] to be converted into a [SerializableList] and sent either as a
      * [ListLoadable.Empty] or a [ListLoadable.Populated].
      * @see Array.toSerializableList
+     * @throws NotSerializableException If any of the [content]'s elements cannot be serialized.
      **/
+    @Throws(NotSerializableException::class)
     suspend fun load(vararg content: T) {
         load(content.toSerializableList())
     }

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/Loadable.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/Loadable.extensions.kt
@@ -1,10 +1,9 @@
 package com.jeanbarrossilva.loadable.list
 
 import com.jeanbarrossilva.loadable.Loadable
-import java.io.Serializable
 
 /** Converts this [Loadable] into a [ListLoadable]. **/
-fun <T : Serializable?> Loadable<SerializableList<T>>.toListLoadable(): ListLoadable<T> {
+fun <T> Loadable<SerializableList<T>>.toListLoadable(): ListLoadable<T> {
     return when (this) {
         is Loadable.Loading -> ListLoadable.Loading()
         is Loadable.Loaded -> content.toListLoadable()

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/SerializableList.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/SerializableList.extensions.kt
@@ -1,9 +1,7 @@
 package com.jeanbarrossilva.loadable.list
 
-import java.io.Serializable
-
 /** Converts this [SerializableList] into a [ListLoadable]. **/
-fun <T : Serializable?> SerializableList<T>.toListLoadable(): ListLoadable<T> {
+fun <T> SerializableList<T>.toListLoadable(): ListLoadable<T> {
     return if (isEmpty()) ListLoadable.Empty() else ListLoadable.Populated(this)
 }
 

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/SerializableList.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/SerializableList.extensions.kt
@@ -1,5 +1,7 @@
 package com.jeanbarrossilva.loadable.list
 
+import java.io.NotSerializableException
+
 /** Converts this [SerializableList] into a [ListLoadable]. **/
 fun <T> SerializableList<T>.toListLoadable(): ListLoadable<T> {
     return if (isEmpty()) ListLoadable.Empty() else ListLoadable.Populated(this)
@@ -18,7 +20,9 @@ fun <T> emptySerializableList(): SerializableList<T> {
  * Creates a new [SerializableList] with the given [elements].
  *
  * @param elements Elements to be added to the [SerializableList].
+ * @throws NotSerializableException If any of the [elements] cannot be serialized.
  **/
+@Throws(NotSerializableException::class)
 fun <T> serializableListOf(vararg elements: T): SerializableList<T> {
     val elementsAsList = elements.toList()
     return SerializableList(elementsAsList)

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/SerializableList.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/SerializableList.kt
@@ -1,12 +1,20 @@
 package com.jeanbarrossilva.loadable.list
 
+import com.jeanbarrossilva.loadable.requireSerializable
+import java.io.NotSerializableException
 import java.io.Serializable
 
 /**
  * [List] that conforms to [Serializable].
  *
  * @param elements Instances of [T] contained in this [SerializableList].
+ * @throws NotSerializableException If any of the [elements] cannot be serialized.
  **/
 @JvmInline
-value class SerializableList<T> internal constructor(private val elements: List<T>) :
-    List<T> by elements, Serializable
+value class SerializableList<T>
+@Throws(NotSerializableException::class)
+internal constructor(private val elements: List<T>) : List<T> by elements, Serializable {
+    init {
+        forEach(::requireSerializable)
+    }
+}

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/flow/Flow.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/flow/Flow.extensions.kt
@@ -2,14 +2,13 @@ package com.jeanbarrossilva.loadable.list.flow
 
 import com.jeanbarrossilva.loadable.list.ListLoadable
 import com.jeanbarrossilva.loadable.list.ListLoadableScope
-import java.io.Serializable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.flow
 
 /** Returns a [Flow] containing only non-[loading][ListLoadable.Loading] values. **/
-fun <T : Serializable?> Flow<ListLoadable<T>>.filterNotLoading(): Flow<ListLoadable<T>> {
+fun <T> Flow<ListLoadable<T>>.filterNotLoading(): Flow<ListLoadable<T>> {
     return filterNot {
         it is ListLoadable.Loading
     }
@@ -22,8 +21,7 @@ fun <T : Serializable?> Flow<ListLoadable<T>>.filterNotLoading(): Flow<ListLoada
  * @param load Operations to be made on the [ListLoadableScope] responsible for emitting
  * [ListLoadable]s sent to it to the created [Flow].
  **/
-fun <T : Serializable?> listLoadableFlow(load: suspend ListLoadableScope<T>.() -> Unit):
-    Flow<ListLoadable<T>> {
+fun <T> listLoadableFlow(load: suspend ListLoadableScope<T>.() -> Unit): Flow<ListLoadable<T>> {
     return emptyListLoadableFlow {
         load()
         load.invoke(this)
@@ -37,9 +35,8 @@ fun <T : Serializable?> listLoadableFlow(load: suspend ListLoadableScope<T>.() -
  * @param load Operations to be made on the [ListLoadableScope] responsible for emitting
  * [ListLoadable]s sent to it to the created [Flow].
  **/
-internal fun <T : Serializable?> emptyListLoadableFlow(
-    load: suspend ListLoadableScope<T>.() -> Unit
-): Flow<ListLoadable<T>> {
+internal fun <T> emptyListLoadableFlow(load: suspend ListLoadableScope<T>.() -> Unit):
+    Flow<ListLoadable<T>> {
     return flow<ListLoadable<T>> {
         FlowCollectorListLoadableScope(this).apply {
             load.invoke(this)

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/flow/FlowCollectorListLoadableScope.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/flow/FlowCollectorListLoadableScope.kt
@@ -2,7 +2,6 @@ package com.jeanbarrossilva.loadable.list.flow
 
 import com.jeanbarrossilva.loadable.list.ListLoadable
 import com.jeanbarrossilva.loadable.list.ListLoadableScope
-import java.io.Serializable
 import kotlinx.coroutines.flow.FlowCollector
 
 /**
@@ -10,7 +9,7 @@ import kotlinx.coroutines.flow.FlowCollector
  *
  * @param collector [FlowCollector] to which sent [ListLoadable]s will be emitted.
  **/
-internal class FlowCollectorListLoadableScope<T : Serializable?>(
+internal class FlowCollectorListLoadableScope<T>(
     private val collector: FlowCollector<ListLoadable<T>>
 ) : ListLoadableScope<T>() {
     override suspend fun send(listLoadable: ListLoadable<T>) {

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/flow/MutableStateFlow.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/flow/MutableStateFlow.extensions.kt
@@ -4,6 +4,7 @@ import com.jeanbarrossilva.loadable.list.ListLoadable
 import com.jeanbarrossilva.loadable.list.SerializableList
 import com.jeanbarrossilva.loadable.list.serializableListOf
 import com.jeanbarrossilva.loadable.list.toListLoadable
+import java.io.NotSerializableException
 import kotlinx.coroutines.flow.MutableStateFlow
 
 /** Creates a [MutableStateFlow] with a [ListLoadable.Loading] as its initial value. **/
@@ -16,7 +17,9 @@ fun <T> listLoadableFlow(): MutableStateFlow<ListLoadable<T>> {
  * matches the given [content].
  *
  * @param content [Array] from which the [ListLoadable] will be created.
+ * @throws NotSerializableException If any of the [content]'s elements cannot be serialized.
  **/
+@Throws(NotSerializableException::class)
 fun <T> listLoadableFlowOf(vararg content: T): MutableStateFlow<ListLoadable<T>> {
     return listLoadableFlowOf(serializableListOf(*content))
 }

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/flow/MutableStateFlow.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/flow/MutableStateFlow.extensions.kt
@@ -4,11 +4,10 @@ import com.jeanbarrossilva.loadable.list.ListLoadable
 import com.jeanbarrossilva.loadable.list.SerializableList
 import com.jeanbarrossilva.loadable.list.serializableListOf
 import com.jeanbarrossilva.loadable.list.toListLoadable
-import java.io.Serializable
 import kotlinx.coroutines.flow.MutableStateFlow
 
 /** Creates a [MutableStateFlow] with a [ListLoadable.Loading] as its initial value. **/
-fun <T : Serializable?> listLoadableFlow(): MutableStateFlow<ListLoadable<T>> {
+fun <T> listLoadableFlow(): MutableStateFlow<ListLoadable<T>> {
     return MutableStateFlow(ListLoadable.Loading())
 }
 
@@ -18,7 +17,7 @@ fun <T : Serializable?> listLoadableFlow(): MutableStateFlow<ListLoadable<T>> {
  *
  * @param content [Array] from which the [ListLoadable] will be created.
  **/
-fun <T : Serializable?> listLoadableFlowOf(vararg content: T): MutableStateFlow<ListLoadable<T>> {
+fun <T> listLoadableFlowOf(vararg content: T): MutableStateFlow<ListLoadable<T>> {
     return listLoadableFlowOf(serializableListOf(*content))
 }
 
@@ -28,7 +27,6 @@ fun <T : Serializable?> listLoadableFlowOf(vararg content: T): MutableStateFlow<
  *
  * @param content [SerializableList] from which the [ListLoadable] will be created.
  **/
-fun <T : Serializable?> listLoadableFlowOf(content: SerializableList<T>):
-    MutableStateFlow<ListLoadable<T>> {
+fun <T> listLoadableFlowOf(content: SerializableList<T>): MutableStateFlow<ListLoadable<T>> {
     return MutableStateFlow(content.toListLoadable())
 }

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/flow/StateFlow.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/flow/StateFlow.extensions.kt
@@ -6,7 +6,6 @@ import com.jeanbarrossilva.loadable.list.ListLoadable
 import com.jeanbarrossilva.loadable.list.ListLoadableScope
 import com.jeanbarrossilva.loadable.list.SerializableList
 import com.jeanbarrossilva.loadable.list.toListLoadable
-import java.io.Serializable
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
@@ -25,7 +24,7 @@ import kotlinx.coroutines.launch
  * [value][StateFlow.value] will be shared.
  * @param sharingStarted Strategy for controlling when sharing starts and ends.
  **/
-fun <T : Serializable?> Flow<SerializableList<T>>.listLoadable(
+fun <T> Flow<SerializableList<T>>.listLoadable(
     coroutineScope: CoroutineScope,
     sharingStarted: SharingStarted
 ): StateFlow<ListLoadable<T>> {
@@ -46,7 +45,7 @@ fun <T : Serializable?> Flow<SerializableList<T>>.listLoadable(
  * @param load Operations to be made on the [ListLoadableScope] responsible for emitting
  * [ListLoadable]s sent to it to the created [StateFlow].
  **/
-fun <T : Serializable?> listLoadableFlow(
+fun <T> listLoadableFlow(
     coroutineScope: CoroutineScope,
     load: suspend ListLoadableScope<T>.() -> Unit
 ): StateFlow<ListLoadable<T>> {

--- a/loadable-list/src/test/java/com/jeanbarrossilva/loadable/list/SerializableListExtensions.kt
+++ b/loadable-list/src/test/java/com/jeanbarrossilva/loadable/list/SerializableListExtensions.kt
@@ -1,6 +1,5 @@
 package com.jeanbarrossilva.loadable.list
 
-import java.io.Serializable
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -22,7 +21,7 @@ internal class SerializableListExtensions {
 
     @Test
     fun `GIVEN a SerializableList created through emptySerializableList WHEN checking if it's empty THEN it is`() { // ktlint-disable max-line-length
-        assertContentEquals(emptyList(), emptySerializableList<Serializable>())
+        assertContentEquals(emptyList(), emptySerializableList<Any?>())
     }
 
     @Test

--- a/loadable-placeholder/src/main/java/com/jeanbarrossilva/loadable/placeholder/Placeholder.kt
+++ b/loadable-placeholder/src/main/java/com/jeanbarrossilva/loadable/placeholder/Placeholder.kt
@@ -18,7 +18,6 @@ import com.google.accompanist.placeholder.placeholder
 import com.jeanbarrossilva.loadable.Loadable
 import com.jeanbarrossilva.loadable.ifLoaded
 import com.jeanbarrossilva.loadable.placeholder.test.Loading
-import java.io.Serializable
 
 /** Default values of a [Placeholder]. **/
 object PlaceholderDefaults {
@@ -41,7 +40,7 @@ object PlaceholderDefaults {
  * @param content Content that's shown if the [loadable] is [loaded][Loadable.Loaded].
  **/
 @Composable
-fun <T : Serializable?> Placeholder(
+fun <T> Placeholder(
     loadable: Loadable<T>,
     modifier: Modifier = Modifier,
     shape: Shape = PlaceholderDefaults.shape,

--- a/loadable-placeholder/src/test/java/com/jeanbarrossilva/loadable/placeholder/PlaceholderTests.kt
+++ b/loadable-placeholder/src/test/java/com/jeanbarrossilva/loadable/placeholder/PlaceholderTests.kt
@@ -44,7 +44,7 @@ internal class PlaceholderTests {
     @Test
     fun isNotLoadingWhenLoadableIsFailed() {
         composeRule.setContent {
-            Placeholder(Loadable.Failed(Exception()), Modifier.tagAsPlaceholder()) {
+            Placeholder(Loadable.Failed<Any?>(Exception()), Modifier.tagAsPlaceholder()) {
             }
         }
         composeRule.onPlaceholder().assertIsNotLoading()

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/Any.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/Any.extensions.kt
@@ -1,6 +1,7 @@
 package com.jeanbarrossilva.loadable
 
-import java.io.Serializable
+import java.io.ByteArrayOutputStream
+import java.io.ObjectOutputStream
 
 /**
  * Converts this into a [Loadable].
@@ -13,11 +14,26 @@ import java.io.Serializable
  * - `null` (with [T] being a non-`null` type), [Loadable.Loading];
  * - of a type other than [T]`?`, `null`.
  **/
-inline fun <reified T : Serializable?> Any?.loadable(): Loadable<T>? {
+inline fun <reified T> Any?.loadable(): Loadable<T>? {
     return when (this) {
         is Throwable -> Loadable.Failed(this)
         is T -> Loadable.Loaded(this)
         null -> Loadable.Loading()
         else -> null
     }
+}
+
+/**
+ * Requires the [value] to be serializable.
+ *
+ * @param value Object whose serialization capability will be required.
+ * @return The [value] itself.
+ **/
+fun <T> requireSerializable(value: T): T {
+    ByteArrayOutputStream().use { byteArrayOutputStream ->
+        ObjectOutputStream(byteArrayOutputStream).use { objectOutputStream ->
+            objectOutputStream.writeObject(value)
+        }
+    }
+    return value
 }

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/Any.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/Any.extensions.kt
@@ -1,6 +1,7 @@
 package com.jeanbarrossilva.loadable
 
 import java.io.ByteArrayOutputStream
+import java.io.NotSerializableException
 import java.io.ObjectOutputStream
 
 /**
@@ -13,7 +14,9 @@ import java.io.ObjectOutputStream
  * - `null` (with [T] being a nullable type), [Loadable.Loaded];
  * - `null` (with [T] being a non-`null` type), [Loadable.Loading];
  * - of a type other than [T]`?`, `null`.
+ * @throws NotSerializableException If this is a [T] and cannot be serialized.
  **/
+@Throws(NotSerializableException::class)
 inline fun <reified T> Any?.loadable(): Loadable<T>? {
     return when (this) {
         is Throwable -> Loadable.Failed(this)

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/Any.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/Any.extensions.kt
@@ -31,7 +31,9 @@ inline fun <reified T> Any?.loadable(): Loadable<T>? {
  *
  * @param value Object whose serialization capability will be required.
  * @return The [value] itself.
+ * @throws NotSerializableException If the [value] cannot be serialized.
  **/
+@Throws(NotSerializableException::class)
 fun <T> requireSerializable(value: T): T {
     ByteArrayOutputStream().use { byteArrayOutputStream ->
         ObjectOutputStream(byteArrayOutputStream).use { objectOutputStream ->

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.extensions.kt
@@ -1,5 +1,7 @@
 package com.jeanbarrossilva.loadable
 
+import java.io.NotSerializableException
+
 /**
  * [Content][Loadable.Loaded.content] of the given [Loadable] if it's [loaded][Loadable.Loaded];
  * otherwise, `null`.
@@ -27,7 +29,10 @@ inline fun <I, O> Loadable<I>.ifLoaded(operation: I.() -> O): O? {
  *
  * @param transform Transformation to be done to the [loaded][Loadable.Loaded]
  * [content][Loadable.Loaded.content].
+ * @throws NotSerializableException If this is [loaded][Loadable.Loaded] and the result of
+ * [transform] cannot be serialized.
  **/
+@Throws(NotSerializableException::class)
 inline fun <I, O> Loadable<I>.map(transform: (I) -> O): Loadable<O> {
     return when (this) {
         is Loadable.Loading -> Loadable.Loading()

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.extensions.kt
@@ -1,12 +1,10 @@
 package com.jeanbarrossilva.loadable
 
-import java.io.Serializable
-
 /**
  * [Content][Loadable.Loaded.content] of the given [Loadable] if it's [loaded][Loadable.Loaded];
  * otherwise, `null`.
  **/
-inline val <T : Serializable?> Loadable<T>.contentOrNull
+inline val <T> Loadable<T>.contentOrNull
     get() = ifLoaded { this }
 
 /**
@@ -16,7 +14,7 @@ inline val <T : Serializable?> Loadable<T>.contentOrNull
  * @param operation Callback to be run on the [loaded][Loadable.Loaded]
  * [content][Loadable.Loaded.content].
  **/
-inline fun <I : Serializable?, O> Loadable<I>.ifLoaded(operation: I.() -> O): O? {
+inline fun <I, O> Loadable<I>.ifLoaded(operation: I.() -> O): O? {
     return if (this is Loadable.Loaded) content.operation() else null
 }
 
@@ -30,8 +28,7 @@ inline fun <I : Serializable?, O> Loadable<I>.ifLoaded(operation: I.() -> O): O?
  * @param transform Transformation to be done to the [loaded][Loadable.Loaded]
  * [content][Loadable.Loaded.content].
  **/
-inline fun <I : Serializable?, O : Serializable?> Loadable<I>.map(transform: (I) -> O):
-    Loadable<O> {
+inline fun <I, O> Loadable<I>.map(transform: (I) -> O): Loadable<O> {
     return when (this) {
         is Loadable.Loading -> Loadable.Loading()
         is Loadable.Loaded -> Loadable.Loaded(transform(content))

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.kt
@@ -1,11 +1,12 @@
 package com.jeanbarrossilva.loadable
 
+import java.io.NotSerializableException
 import java.io.Serializable
 
 /** Different stages of asynchronously-loaded content. **/
-sealed interface Loadable<T : Serializable?> : Serializable {
+sealed interface Loadable<T> : Serializable {
     /** Stage in which the content is being loaded and, therefore, is temporarily unavailable. **/
-    class Loading<T : Serializable?> : Loadable<T> {
+    class Loading<T> : Loadable<T> {
         override fun toString(): String {
             return "Loading"
         }
@@ -15,9 +16,16 @@ sealed interface Loadable<T : Serializable?> : Serializable {
      * Stage in which the content has been successfully loaded.
      *
      * @param content Value that's been loaded.
+     * @throws NotSerializableException If [content] cannot be serialized.
      **/
     @JvmInline
-    value class Loaded<T : Serializable?>(val content: T) : Loadable<T>
+    value class Loaded<T>
+    @Throws(NotSerializableException::class)
+    constructor(val content: T) : Loadable<T> {
+        init {
+            requireSerializable(content)
+        }
+    }
 
     /**
      * Stage in which the content has failed to load and threw [error].
@@ -25,5 +33,5 @@ sealed interface Loadable<T : Serializable?> : Serializable {
      * @param error [Throwable] that's been thrown while trying to load the content.
      **/
     @JvmInline
-    value class Failed<T : Serializable?>(val error: Throwable) : Loadable<T>
+    value class Failed<T>(val error: Throwable) : Loadable<T>
 }

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/LoadableScope.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/LoadableScope.extensions.kt
@@ -1,14 +1,11 @@
 package com.jeanbarrossilva.loadable
 
-import java.io.Serializable
-
 /**
  * Creates a [LoadableScope] with [send] as its [LoadableScope.send] callback.
  *
  * @param send Callback run whenever a [Loadable] is sent.
  **/
-@Suppress("FunctionName")
-internal fun <T : Serializable?> LoadableScope(send: (Loadable<T>) -> Unit): LoadableScope<T> {
+internal fun <T> LoadableScope(send: (Loadable<T>) -> Unit): LoadableScope<T> {
     return object : LoadableScope<T>() {
         override suspend fun send(loadable: Loadable<T>) {
             send(loadable)

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/LoadableScope.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/LoadableScope.kt
@@ -1,9 +1,7 @@
 package com.jeanbarrossilva.loadable
 
-import java.io.Serializable
-
 /** Scope through which [Loadable]s are sent. **/
-abstract class LoadableScope<T : Serializable?> internal constructor() {
+abstract class LoadableScope<T> internal constructor() {
     /** Sends a [Loadable.Loading]. **/
     suspend fun load() {
         send(Loadable.Loading())

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/LoadableScope.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/LoadableScope.kt
@@ -1,5 +1,7 @@
 package com.jeanbarrossilva.loadable
 
+import java.io.NotSerializableException
+
 /** Scope through which [Loadable]s are sent. **/
 abstract class LoadableScope<T> internal constructor() {
     /** Sends a [Loadable.Loading]. **/
@@ -11,7 +13,9 @@ abstract class LoadableScope<T> internal constructor() {
      * Sends a [Loadable.Loaded] with the given [content].
      *
      * @param content Value to be set as the [Loadable.Loaded.content].
+     * @throws NotSerializableException If the [content] cannot be serialized.
      **/
+    @Throws(NotSerializableException::class)
     suspend fun load(content: T) {
         send(Loadable.Loaded(content))
     }

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/Flow.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/Flow.extensions.kt
@@ -4,7 +4,6 @@ import com.jeanbarrossilva.loadable.Loadable
 import com.jeanbarrossilva.loadable.LoadableScope
 import com.jeanbarrossilva.loadable.ifLoaded
 import com.jeanbarrossilva.loadable.map
-import java.io.Serializable
 import kotlin.experimental.ExperimentalTypeInference
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.flow.Flow
@@ -17,12 +16,12 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.withIndex
 
 /** Returns a [Flow] containing only [failed][Loadable.Failed] values. **/
-fun <T : Serializable?> Flow<Loadable<T>>.filterIsFailed(): Flow<Loadable.Failed<T>> {
+fun <T> Flow<Loadable<T>>.filterIsFailed(): Flow<Loadable.Failed<T>> {
     return filterIsInstance()
 }
 
 /** Returns a [Flow] containing only [loaded][Loadable.Loaded] values. **/
-fun <T : Serializable?> Flow<Loadable<T>>.filterIsLoaded(): Flow<Loadable.Loaded<T>> {
+fun <T> Flow<Loadable<T>>.filterIsLoaded(): Flow<Loadable.Loaded<T>> {
     return filterIsInstance()
 }
 
@@ -32,8 +31,7 @@ fun <T : Serializable?> Flow<Loadable<T>>.filterIsLoaded(): Flow<Loadable.Loaded
  *
  * @param transform Transformation to be done to the [content][Loadable.Loaded.content].
  **/
-fun <I : Serializable?, O : Serializable?> Flow<Loadable<I>>.innerMap(transform: suspend (I) -> O):
-    Flow<Loadable<O>> {
+fun <I, O> Flow<Loadable<I>>.innerMap(transform: suspend (I) -> O): Flow<Loadable<O>> {
     return map { loadable: Loadable<I> ->
         loadable.map {
             transform(it)
@@ -47,7 +45,7 @@ fun <I : Serializable?, O : Serializable?> Flow<Loadable<I>>.innerMap(transform:
  * Emits, initially, [Loadable.Loading], [Loadable.Loaded] for each value and [Loadable.Failed] for
  * thrown [Throwable]s.
  **/
-fun <T : Serializable?> Flow<T>.loadable(): Flow<Loadable<T>> {
+fun <T> Flow<T>.loadable(): Flow<Loadable<T>> {
     return loadableFlow {
         collect(::load)
     }
@@ -62,7 +60,7 @@ fun <T : Serializable?> Flow<T>.loadable(): Flow<Loadable<T>> {
  * [loaded][Loadable.Loaded];
  * - [LoadableScope.fail] with the [error][Loadable.Failed.error] when [failed][Loadable.Failed].
  **/
-suspend fun <T : Serializable?> Flow<T>.loadTo(loadableScope: LoadableScope<T>) {
+suspend fun <T> Flow<T>.loadTo(loadableScope: LoadableScope<T>) {
     loadable()
         // Ignores the initial loading stage, since public Loadable-Flow-creator functions'
         // LoadableScope always loads.
@@ -79,7 +77,7 @@ suspend fun <T : Serializable?> Flow<T>.loadTo(loadableScope: LoadableScope<T>) 
  * [loaded][Loadable.Loaded];
  * - [LoadableScope.fail] with the [error][Loadable.Failed.error] when [failed][Loadable.Failed].
  **/
-suspend fun <T : Serializable?> Flow<Loadable<T>>.sendTo(loadableScope: LoadableScope<T>) {
+suspend fun <T> Flow<Loadable<T>>.sendTo(loadableScope: LoadableScope<T>) {
     collect(loadableScope::send)
 }
 
@@ -87,7 +85,7 @@ suspend fun <T : Serializable?> Flow<Loadable<T>>.sendTo(loadableScope: Loadable
  * Unwraps [Loadable.Loaded] emissions and returns a [Flow] containing only their
  * [content][Loadable.Loaded.content]s.
  **/
-fun <T : Serializable?> Flow<Loadable<T>>.unwrap(): Flow<T> {
+fun <T> Flow<Loadable<T>>.unwrap(): Flow<T> {
     return filterIsLoaded().map {
         it.content
     }
@@ -97,7 +95,7 @@ fun <T : Serializable?> Flow<Loadable<T>>.unwrap(): Flow<T> {
  * Unwraps [Loadable.Loaded] emissions and returns a [Flow] containing only those that have a
  * non-`null` [content][Loadable.Loaded.content].
  **/
-fun <T : Serializable> Flow<Loadable<T?>>.unwrapContent(): Flow<Loadable<T>> {
+fun <T : Any> Flow<Loadable<T?>>.unwrapContent(): Flow<Loadable<T>> {
     @Suppress("UNCHECKED_CAST")
     return filter {
         it.ifLoaded { this != null } ?: true
@@ -111,7 +109,7 @@ fun <T : Serializable> Flow<Loadable<T?>>.unwrapContent(): Flow<Loadable<T>> {
  * @param load Operations to be made on the [LoadableScope] responsible for emitting [Loadable]s
  * sent to it to the created [Flow].
  **/
-fun <T : Serializable?> loadableFlow(load: suspend LoadableScope<T>.() -> Unit): Flow<Loadable<T>> {
+fun <T> loadableFlow(load: suspend LoadableScope<T>.() -> Unit): Flow<Loadable<T>> {
     return emptyLoadableFlow {
         load()
         load.invoke(this)
@@ -125,9 +123,8 @@ fun <T : Serializable?> loadableFlow(load: suspend LoadableScope<T>.() -> Unit):
  * [Flow].
  **/
 @OptIn(ExperimentalTypeInference::class)
-fun <T : Serializable?> loadableChannelFlow(
-    @BuilderInference block: suspend ProducerScope<Loadable<T>>.() -> Unit
-): Flow<Loadable<T>> {
+fun <T> loadableChannelFlow(@BuilderInference block: suspend ProducerScope<Loadable<T>>.() -> Unit):
+    Flow<Loadable<T>> {
     return channelFlow {
         send(Loadable.Loading())
         block()
@@ -142,8 +139,7 @@ fun <T : Serializable?> loadableChannelFlow(
  * @param load Operations to be made on the [LoadableScope] responsible for emitting [Loadable]s
  * sent to it to the created [Flow].
  **/
-internal fun <T : Serializable?> emptyLoadableFlow(load: suspend LoadableScope<T>.() -> Unit):
-    Flow<Loadable<T>> {
+internal fun <T> emptyLoadableFlow(load: suspend LoadableScope<T>.() -> Unit): Flow<Loadable<T>> {
     return flow<Loadable<T>> {
         FlowCollectorLoadableScope(this).apply {
             load.invoke(this)
@@ -165,7 +161,7 @@ private fun <T> Flow<T>.ignore(count: Int): Flow<T> {
 }
 
 /** Catches thrown exceptions by emitting a [Loadable.Failed]. **/
-private fun <T : Serializable?> Flow<Loadable<T>>.catchAsFailed(): Flow<Loadable<T>> {
+private fun <T> Flow<Loadable<T>>.catchAsFailed(): Flow<Loadable<T>> {
     return catch {
         emit(Loadable.Failed(it))
     }

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/Flow.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/Flow.extensions.kt
@@ -4,6 +4,7 @@ import com.jeanbarrossilva.loadable.Loadable
 import com.jeanbarrossilva.loadable.LoadableScope
 import com.jeanbarrossilva.loadable.ifLoaded
 import com.jeanbarrossilva.loadable.map
+import java.io.NotSerializableException
 import kotlin.experimental.ExperimentalTypeInference
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.flow.Flow
@@ -44,6 +45,9 @@ fun <I, O> Flow<Loadable<I>>.innerMap(transform: suspend (I) -> O): Flow<Loadabl
  *
  * Emits, initially, [Loadable.Loading], [Loadable.Loaded] for each value and [Loadable.Failed] for
  * thrown [Throwable]s.
+ *
+ * **NOTE**: Emitting a value that cannot be serialized to the resulting [Flow] and performing a
+ * terminal operation on it will result in a [NotSerializableException] being thrown.
  **/
 fun <T> Flow<T>.loadable(): Flow<Loadable<T>> {
     return loadableFlow {
@@ -59,7 +63,11 @@ fun <T> Flow<T>.loadable(): Flow<Loadable<T>> {
  * - [LoadableScope.load] with the [content][Loadable.Loaded.content] when
  * [loaded][Loadable.Loaded];
  * - [LoadableScope.fail] with the [error][Loadable.Failed.error] when [failed][Loadable.Failed].
+ *
+ * @throws NotSerializableException If a value that cannot be serialized is emitted to this [Flow]
+ * and, consequently, sent to the [loadableScope].
  **/
+@Throws(NotSerializableException::class)
 suspend fun <T> Flow<T>.loadTo(loadableScope: LoadableScope<T>) {
     loadable()
         // Ignores the initial loading stage, since public Loadable-Flow-creator functions'

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/FlowCollector.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/FlowCollector.extensions.kt
@@ -1,13 +1,16 @@
 package com.jeanbarrossilva.loadable.flow
 
 import com.jeanbarrossilva.loadable.Loadable
+import java.io.NotSerializableException
 import kotlinx.coroutines.flow.FlowCollector
 
 /**
- * Emits the given [element] as a [Loadable.Loaded].
+ * Emits the given [content] as a [Loadable.Loaded].
  *
- * @param element Element to be emitted.
+ * @param content Element to be emitted.
+ * @throws NotSerializableException If the [content] cannot be serialized.
  **/
-internal suspend fun <T> FlowCollector<Loadable<T>>.emit(element: T) {
-    emit(Loadable.Loaded(element))
+@Throws(NotSerializableException::class)
+internal suspend fun <T> FlowCollector<Loadable<T>>.emit(content: T) {
+    emit(Loadable.Loaded(content))
 }

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/FlowCollector.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/FlowCollector.extensions.kt
@@ -1,7 +1,6 @@
 package com.jeanbarrossilva.loadable.flow
 
 import com.jeanbarrossilva.loadable.Loadable
-import java.io.Serializable
 import kotlinx.coroutines.flow.FlowCollector
 
 /**
@@ -9,6 +8,6 @@ import kotlinx.coroutines.flow.FlowCollector
  *
  * @param element Element to be emitted.
  **/
-internal suspend fun <T : Serializable?> FlowCollector<Loadable<T>>.emit(element: T) {
+internal suspend fun <T> FlowCollector<Loadable<T>>.emit(element: T) {
     emit(Loadable.Loaded(element))
 }

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/FlowCollectorLoadableScope.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/FlowCollectorLoadableScope.kt
@@ -2,7 +2,6 @@ package com.jeanbarrossilva.loadable.flow
 
 import com.jeanbarrossilva.loadable.Loadable
 import com.jeanbarrossilva.loadable.LoadableScope
-import java.io.Serializable
 import kotlinx.coroutines.flow.FlowCollector
 
 /**
@@ -11,7 +10,7 @@ import kotlinx.coroutines.flow.FlowCollector
  * @param collector [FlowCollector] to which sent [Loadable]s will be emitted.
  **/
 @PublishedApi
-internal class FlowCollectorLoadableScope<T : Serializable?>(
+internal class FlowCollectorLoadableScope<T>(
     private val collector: FlowCollector<Loadable<T>>
 ) : LoadableScope<T>() {
     override suspend fun send(loadable: Loadable<T>) {

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/MutableStateFlow.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/MutableStateFlow.extensions.kt
@@ -2,6 +2,7 @@ package com.jeanbarrossilva.loadable.flow
 
 import com.jeanbarrossilva.loadable.Loadable
 import com.jeanbarrossilva.loadable.LoadableScope
+import java.io.NotSerializableException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,6 +14,9 @@ import kotlinx.coroutines.launch
  *
  * Emits, initially, [Loadable.Loading], [Loadable.Loaded] for each value and [Loadable.Failed] for
  * thrown [Throwable]s.
+ *
+ * **NOTE**: Emitting a value that cannot be serialized to the resulting [MutableStateFlow] and
+ * performing a terminal operation on it will result in a [NotSerializableException] being thrown.
  *
  * @param coroutineScope [CoroutineScope] in which the resulting [MutableStateFlow] will be started
  * and its [value][MutableStateFlow.value] will be shared.
@@ -47,7 +51,12 @@ fun <T> loadableFlow(): MutableStateFlow<Loadable<T>> {
     return MutableStateFlow(Loadable.Loading())
 }
 
-/** Creates a [MutableStateFlow] with a [Loadable.Loaded] that wraps the given [content]. **/
+/**
+ * Creates a [MutableStateFlow] with a [Loadable.Loaded] that wraps the given [content].
+ *
+ * @throws NotSerializableException If the [content] cannot be serialized.
+ **/
+@Throws(NotSerializableException::class)
 fun <T> loadableFlowOf(content: T): MutableStateFlow<Loadable<T>> {
     return MutableStateFlow(Loadable.Loaded(content))
 }

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/MutableStateFlow.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/MutableStateFlow.extensions.kt
@@ -2,7 +2,6 @@ package com.jeanbarrossilva.loadable.flow
 
 import com.jeanbarrossilva.loadable.Loadable
 import com.jeanbarrossilva.loadable.LoadableScope
-import java.io.Serializable
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,8 +17,7 @@ import kotlinx.coroutines.launch
  * @param coroutineScope [CoroutineScope] in which the resulting [MutableStateFlow] will be started
  * and its [value][MutableStateFlow.value] will be shared.
  **/
-fun <T : Serializable?> Flow<T>.loadable(coroutineScope: CoroutineScope):
-    MutableStateFlow<Loadable<T>> {
+fun <T> Flow<T>.loadable(coroutineScope: CoroutineScope): MutableStateFlow<Loadable<T>> {
     return loadableFlow(coroutineScope) {
         collect(::load)
     }
@@ -35,10 +33,8 @@ fun <T : Serializable?> Flow<T>.loadable(coroutineScope: CoroutineScope):
  * @param load Operations to be made on the [LoadableScope] responsible for emitting [Loadable]s
  * sent to it to the created [MutableStateFlow].
  **/
-fun <T : Serializable?> loadableFlow(
-    coroutineScope: CoroutineScope,
-    load: suspend LoadableScope<T>.() -> Unit
-): MutableStateFlow<Loadable<T>> {
+fun <T> loadableFlow(coroutineScope: CoroutineScope, load: suspend LoadableScope<T>.() -> Unit):
+    MutableStateFlow<Loadable<T>> {
     return loadableFlow<T>().apply {
         coroutineScope.launch {
             emitAll(emptyLoadableFlow(load))
@@ -47,11 +43,11 @@ fun <T : Serializable?> loadableFlow(
 }
 
 /** Creates a [MutableStateFlow] with a [Loadable.Loading] as its initial value. **/
-fun <T : Serializable?> loadableFlow(): MutableStateFlow<Loadable<T>> {
+fun <T> loadableFlow(): MutableStateFlow<Loadable<T>> {
     return MutableStateFlow(Loadable.Loading())
 }
 
 /** Creates a [MutableStateFlow] with a [Loadable.Loaded] that wraps the given [content]. **/
-fun <T : Serializable?> loadableFlowOf(content: T): MutableStateFlow<Loadable<T>> {
+fun <T> loadableFlowOf(content: T): MutableStateFlow<Loadable<T>> {
     return MutableStateFlow(Loadable.Loaded(content))
 }

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/ProducerScope.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/ProducerScope.extensions.kt
@@ -1,7 +1,6 @@
 package com.jeanbarrossilva.loadable.flow
 
 import com.jeanbarrossilva.loadable.Loadable
-import java.io.Serializable
 import kotlinx.coroutines.channels.ProducerScope
 
 /**
@@ -9,6 +8,6 @@ import kotlinx.coroutines.channels.ProducerScope
  *
  * @param element Element to be sent.
  **/
-suspend fun <T : Serializable?> ProducerScope<Loadable<T>>.send(element: T) {
+suspend fun <T> ProducerScope<Loadable<T>>.send(element: T) {
     send(Loadable.Loaded(element))
 }

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/ProducerScope.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/ProducerScope.extensions.kt
@@ -1,13 +1,16 @@
 package com.jeanbarrossilva.loadable.flow
 
 import com.jeanbarrossilva.loadable.Loadable
+import java.io.NotSerializableException
 import kotlinx.coroutines.channels.ProducerScope
 
 /**
- * Sends the given [element] as a [Loadable.Loaded].
+ * Sends the given [content] as a [Loadable.Loaded].
  *
- * @param element Element to be sent.
+ * @param content Element to be sent.
+ * @throws NotSerializableException If the [content] cannot be serialized.
  **/
-suspend fun <T> ProducerScope<Loadable<T>>.send(element: T) {
-    send(Loadable.Loaded(element))
+@Throws(NotSerializableException::class)
+suspend fun <T> ProducerScope<Loadable<T>>.send(content: T) {
+    send(Loadable.Loaded(content))
 }

--- a/loadable/src/test/java/com/jeanbarrossilva/loadable/AnyExtensionsTests.kt
+++ b/loadable/src/test/java/com/jeanbarrossilva/loadable/AnyExtensionsTests.kt
@@ -1,6 +1,5 @@
 package com.jeanbarrossilva.loadable
 
-import java.io.Serializable
 import java.util.Stack
 import kotlin.test.assertIs
 import kotlin.test.assertNull
@@ -11,22 +10,22 @@ internal class AnyExtensionsTests {
     @Test
     fun `GIVEN a Throwable WHEN converting it into a Loadable THEN it's failed`() {
         val throwable = NullPointerException()
-        assertEquals(Loadable.Failed<Serializable>(throwable), throwable.loadable<Serializable>())
+        assertEquals(Loadable.Failed<Any?>(throwable), throwable.loadable<Any?>())
     }
 
     @Test
     fun `GIVEN a null Any WHEN converting it into a Loadable of nullable Any THEN it's loaded`() {
-        assertEquals(Loadable.Loaded(null), (null as Serializable?).loadable<Serializable?>())
+        assertEquals(Loadable.Loaded(null), null.loadable<Any?>())
     }
 
     @Test
-    fun `GIVEN a non-null Serializable WHEN converting it into a Loadable of Serializable THEN it's loaded`() { // ktlint-disable max-line-length
-        assertEquals(Loadable.Loaded(0), 0.loadable<Serializable>())
+    fun `GIVEN a non-null Any WHEN converting it into a Loadable of nullable Any THEN it's loaded`() { // ktlint-disable max-line-length
+        assertEquals(Loadable.Loaded(0), 0.loadable<Any?>())
     }
 
     @Test
     fun `GIVEN a null Any WHEN converting it into a Loadable of non-null Any THEN it's loading`() {
-        assertIs<Loadable.Loading<Serializable>>((null as Serializable?).loadable<Serializable>())
+        assertIs<Loadable.Loading<Any>>(null.loadable<Any>())
     }
 
     @Test

--- a/loadable/src/test/java/com/jeanbarrossilva/loadable/AnyExtensionsTests.kt
+++ b/loadable/src/test/java/com/jeanbarrossilva/loadable/AnyExtensionsTests.kt
@@ -1,10 +1,12 @@
 package com.jeanbarrossilva.loadable
 
+import java.io.NotSerializableException
 import java.util.Stack
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import org.junit.Assert.assertEquals
-import org.junit.Test
 
 internal class AnyExtensionsTests {
     @Test
@@ -31,5 +33,17 @@ internal class AnyExtensionsTests {
     @Test
     fun `GIVEN a non-null object WHEN converting it into a Loadable of a different type THEN it's null`() { // ktlint-disable max-line-length
         assertNull(0.loadable<Array<Stack<String>>>())
+    }
+
+    @Test
+    fun `GIVEN an un-serializable object WHEN requiring it to be serializable THEN it throws`() {
+        assertFailsWith<NotSerializableException> {
+            requireSerializable(Thread.UncaughtExceptionHandler { _, _ -> })
+        }
+    }
+
+    @Test
+    fun `GIVEN a serializable object WHEN requiring it to be serializable THEN it is`() {
+        requireSerializable(listOf(1, 2, 3))
     }
 }

--- a/loadable/src/test/java/com/jeanbarrossilva/loadable/LoadableScopeTests.kt
+++ b/loadable/src/test/java/com/jeanbarrossilva/loadable/LoadableScopeTests.kt
@@ -1,6 +1,5 @@
 package com.jeanbarrossilva.loadable
 
-import java.io.Serializable
 import kotlin.test.assertIs
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -8,8 +7,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class LoadableScopeTests {
-    private val sent = mutableListOf<Loadable<Serializable?>>()
-    private val scope: LoadableScope<Serializable?> = LoadableScope(sent::add)
+    private val sent = mutableListOf<Loadable<Any?>>()
+    private val scope: LoadableScope<Any?> = LoadableScope(sent::add)
 
     @After
     fun tearDown() {
@@ -19,7 +18,7 @@ internal class LoadableScopeTests {
     @Test
     fun `GIVEN a Loading Loadable WHEN sending it to the scope THEN it's received`() {
         runTest { scope.load() }
-        assertIs<Loadable.Loading<Serializable?>>(sent.single())
+        assertIs<Loadable.Loading<Any?>>(sent.single())
     }
 
     @Test
@@ -32,7 +31,7 @@ internal class LoadableScopeTests {
     fun `GIVEN a Failed Loadable WHEN sending it to the scope THEN it's received`() {
         runTest { scope.fail(NullPointerException()) }
         sent.single().let {
-            assertIs<Loadable.Failed<Serializable?>>(it)
+            assertIs<Loadable.Failed<Any?>>(it)
             assertIs<NullPointerException>(it.error)
         }
     }

--- a/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
+++ b/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
@@ -2,7 +2,6 @@ package com.jeanbarrossilva.loadable.flow
 
 import app.cash.turbine.test
 import com.jeanbarrossilva.loadable.Loadable
-import java.io.Serializable
 import kotlin.test.Test
 import kotlin.test.assertIs
 import kotlinx.coroutines.flow.flow
@@ -14,8 +13,8 @@ internal class FlowExtensionsTests {
     @Test
     fun `GIVEN a Loadable Flow built through a scope WHEN loading THEN a Loading has been emitted`() { // ktlint-disable max-line-length
         runTest {
-            loadableFlow<Serializable?> { load() }.test {
-                repeat(2) { assertIs<Loadable.Loading<Serializable?>>(awaitItem()) }
+            loadableFlow<Any?> { load() }.test {
+                repeat(2) { assertIs<Loadable.Loading<Any?>>(awaitItem()) }
                 awaitComplete()
             }
         }
@@ -24,7 +23,7 @@ internal class FlowExtensionsTests {
     @Test
     fun `GIVEN a Loadable Flow built through a scope WHEN loaded THEN a Loaded has been emitted`() {
         runTest {
-            loadableFlow<Serializable?> { load(null) }.unwrap().test {
+            loadableFlow<Any?> { load(null) }.unwrap().test {
                 assertEquals(null, awaitItem())
                 awaitComplete()
             }
@@ -34,7 +33,7 @@ internal class FlowExtensionsTests {
     @Test
     fun `GIVEN a Loadable Flow built through a scope WHEN failed THEN a Failed has been emitted`() {
         runTest {
-            loadableFlow<Serializable?> { fail(NullPointerException()) }.filterIsFailed().test {
+            loadableFlow<Any?> { fail(NullPointerException()) }.filterIsFailed().test {
                 awaitItem()
                 awaitComplete()
             }
@@ -44,8 +43,8 @@ internal class FlowExtensionsTests {
     @Test
     fun `GIVEN a Loadable Flow without an initial content WHEN collecting it THEN the value that's emitted first is a Loading one`() { // ktlint-disable max-line-length
         runTest {
-            loadableFlow<Serializable>().test {
-                assertIs<Loadable.Loading<Serializable>>(awaitItem())
+            loadableFlow<Any>().test {
+                assertIs<Loadable.Loading<Any>>(awaitItem())
             }
         }
     }
@@ -136,7 +135,7 @@ internal class FlowExtensionsTests {
     @Test
     fun `GIVEN a Flow WHEN converting it into a Loadable one THEN thrown exceptions are emitted as Failed`() { // ktlint-disable max-line-length
         runTest {
-            flow<Serializable> { 0 / 0 }
+            flow<Any> { 0 / 0 }
                 .loadable()
                 .filterIsFailed()
                 .test {
@@ -198,8 +197,8 @@ internal class FlowExtensionsTests {
     @Test
     fun `GIVEN a Loadable Flow that's Loading WHEN sending its Loadables into a LoadableScope THEN it loads`() { // ktlint-disable max-line-length
         runTest {
-            emptyLoadableFlow(loadableFlow<Serializable?>()::sendTo).test {
-                assertIs<Loadable.Loading<Serializable?>>(awaitItem())
+            emptyLoadableFlow(loadableFlow<Any?>()::sendTo).test {
+                assertIs<Loadable.Loading<Any?>>(awaitItem())
             }
         }
     }
@@ -221,11 +220,11 @@ internal class FlowExtensionsTests {
         val error = Throwable()
         runTest {
             loadableFlow {
-                emptyLoadableFlow<Serializable?> { fail(error) }.sendTo(this)
+                emptyLoadableFlow<Any?> { fail(error) }.sendTo(this)
             }
                 .test {
                     awaitItem()
-                    assertEquals(Loadable.Failed<Serializable?>(error), awaitItem())
+                    assertEquals(Loadable.Failed<Any?>(error), awaitItem())
                     awaitComplete()
                 }
         }


### PR DESCRIPTION
Enforces [`Loadable`](https://github.com/jeanbarrossilva/loadable/blob/a1918f5472f3d14f7875b078d6847fcfbfce3c46/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.kt)'s, [`ListLoadable`](https://github.com/jeanbarrossilva/loadable/blob/a1918f5472f3d14f7875b078d6847fcfbfce3c46/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/ListLoadable.kt)'s and [`SerializableList`](https://github.com/jeanbarrossilva/loadable/blob/a1918f5472f3d14f7875b078d6847fcfbfce3c46/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/SerializableList.kt)'s serializability at runtime instead of requiring their contents to conform to [`Serializable`](https://docs.oracle.com/javase/8/docs/api/java/io/Serializable.html).