### PR TITLE
Opt-in serializability enforcement

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -16,8 +16,8 @@ object Versions {
     val java = JavaVersion.VERSION_11
 
     object Loadable {
-        const val CODE = 19
-        const val NAME = "1.6.6"
+        const val CODE = 20
+        const val NAME = "1.6.7"
         const val SDK_COMPILE = 33
         const val SDK_MIN = 21
         const val SDK_TARGET = SDK_COMPILE

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/Array.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/Array.extensions.kt
@@ -1,13 +1,18 @@
 package com.jeanbarrossilva.loadable.list
 
+import com.jeanbarrossilva.loadable.Serializability
 import java.io.NotSerializableException
 
 /**
  * Converts this [Array] into a [SerializableList].
  *
+ * @param serializability Determines whether each of the elements should be serializable.
+ * @throws NotSerializableException If [serializability] is [enforced][Serializability.ENFORCED] and
+ * any of the elements cannot be serialized.
  * @throws NotSerializableException If any of the elements cannot be serialized.
  **/
 @Throws(NotSerializableException::class)
-fun <T> Array<out T>.toSerializableList(): SerializableList<T> {
-    return serializableListOf(*this)
+fun <T> Array<out T>.toSerializableList(serializability: Serializability = Serializability.default):
+    SerializableList<T> {
+    return serializableListOf(*this, serializability = serializability)
 }

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/ListLoadableScope.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/ListLoadableScope.kt
@@ -1,5 +1,6 @@
 package com.jeanbarrossilva.loadable.list
 
+import com.jeanbarrossilva.loadable.Serializability
 import java.io.NotSerializableException
 
 /** Scope through which [ListLoadable]s are sent. **/
@@ -14,12 +15,17 @@ abstract class ListLoadableScope<T> internal constructor() {
      *
      * @param content [Array] to be converted into a [SerializableList] and sent either as a
      * [ListLoadable.Empty] or a [ListLoadable.Populated].
+     * @param serializability Determines whether each [content] element should be serializable.
      * @see Array.toSerializableList
-     * @throws NotSerializableException If any of the [content]'s elements cannot be serialized.
+     * @throws NotSerializableException If [serializability] is [enforced][Serializability.ENFORCED]
+     * and any of the [content]'s elements cannot be serialized.
      **/
     @Throws(NotSerializableException::class)
-    suspend fun load(vararg content: T) {
-        load(content.toSerializableList())
+    suspend fun load(
+        vararg content: T,
+        serializability: Serializability = Serializability.IGNORED
+    ) {
+        load(content.toSerializableList(serializability))
     }
 
     /**

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/SerializableList.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/SerializableList.extensions.kt
@@ -1,5 +1,6 @@
 package com.jeanbarrossilva.loadable.list
 
+import com.jeanbarrossilva.loadable.Serializability
 import java.io.NotSerializableException
 
 /** Converts this [SerializableList] into a [ListLoadable]. **/
@@ -20,10 +21,15 @@ fun <T> emptySerializableList(): SerializableList<T> {
  * Creates a new [SerializableList] with the given [elements].
  *
  * @param elements Elements to be added to the [SerializableList].
- * @throws NotSerializableException If any of the [elements] cannot be serialized.
+ * @param serializability Determines whether each of the [elements] should be serializable.
+ * @throws NotSerializableException If [serializability] is [enforced][Serializability.ENFORCED] and
+ * any of the [elements] cannot be serialized.
  **/
 @Throws(NotSerializableException::class)
-fun <T> serializableListOf(vararg elements: T): SerializableList<T> {
+fun <T> serializableListOf(
+    vararg elements: T,
+    serializability: Serializability = Serializability.default
+): SerializableList<T> {
     val elementsAsList = elements.toList()
-    return SerializableList(elementsAsList)
+    return SerializableList(serializability, elementsAsList)
 }

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/SerializableList.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/SerializableList.kt
@@ -1,20 +1,22 @@
 package com.jeanbarrossilva.loadable.list
 
-import com.jeanbarrossilva.loadable.requireSerializable
+import com.jeanbarrossilva.loadable.Serializability
 import java.io.NotSerializableException
 import java.io.Serializable
 
 /**
  * [List] that conforms to [Serializable].
  *
+ * @param serializability Determines whether each of the [elements] should be serializable.
  * @param elements Instances of [T] contained in this [SerializableList].
- * @throws NotSerializableException If any of the [elements] cannot be serialized.
+ * @throws NotSerializableException If [serializability] is [enforced][Serializability.ENFORCED] and
+ * any of the [elements] cannot be serialized.
  **/
-@JvmInline
-value class SerializableList<T>
+data class SerializableList<T>
 @Throws(NotSerializableException::class)
-internal constructor(private val elements: List<T>) : List<T> by elements, Serializable {
+internal constructor(val serializability: Serializability, private val elements: List<T>) :
+    List<T> by elements, Serializable {
     init {
-        forEach(::requireSerializable)
+        forEach(serializability::check)
     }
 }

--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/flow/MutableStateFlow.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/flow/MutableStateFlow.extensions.kt
@@ -1,5 +1,6 @@
 package com.jeanbarrossilva.loadable.list.flow
 
+import com.jeanbarrossilva.loadable.Serializability
 import com.jeanbarrossilva.loadable.list.ListLoadable
 import com.jeanbarrossilva.loadable.list.SerializableList
 import com.jeanbarrossilva.loadable.list.serializableListOf
@@ -17,11 +18,16 @@ fun <T> listLoadableFlow(): MutableStateFlow<ListLoadable<T>> {
  * matches the given [content].
  *
  * @param content [Array] from which the [ListLoadable] will be created.
- * @throws NotSerializableException If any of the [content]'s elements cannot be serialized.
+ * @param serializability Determines whether each [content] element should be serializable.
+ * @throws NotSerializableException If [serializability] is [enforced][Serializability.ENFORCED] and
+ * any of the [content]'s elements cannot be serialized.
  **/
 @Throws(NotSerializableException::class)
-fun <T> listLoadableFlowOf(vararg content: T): MutableStateFlow<ListLoadable<T>> {
-    return listLoadableFlowOf(serializableListOf(*content))
+fun <T> listLoadableFlowOf(
+    vararg content: T,
+    serializability: Serializability = Serializability.default
+): MutableStateFlow<ListLoadable<T>> {
+    return listLoadableFlowOf(serializableListOf(*content, serializability = serializability))
 }
 
 /**

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/Any.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/Any.extensions.kt
@@ -1,8 +1,6 @@
 package com.jeanbarrossilva.loadable
 
-import java.io.ByteArrayOutputStream
 import java.io.NotSerializableException
-import java.io.ObjectOutputStream
 
 /**
  * Converts this into a [Loadable].
@@ -24,21 +22,4 @@ inline fun <reified T> Any?.loadable(): Loadable<T>? {
         null -> Loadable.Loading()
         else -> null
     }
-}
-
-/**
- * Requires the [value] to be serializable.
- *
- * @param value Object whose serialization capability will be required.
- * @return The [value] itself.
- * @throws NotSerializableException If the [value] cannot be serialized.
- **/
-@Throws(NotSerializableException::class)
-fun <T> requireSerializable(value: T): T {
-    ByteArrayOutputStream().use { byteArrayOutputStream ->
-        ObjectOutputStream(byteArrayOutputStream).use { objectOutputStream ->
-            objectOutputStream.writeObject(value)
-        }
-    }
-    return value
 }

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.extensions.kt
@@ -36,7 +36,7 @@ inline fun <I, O> Loadable<I>.ifLoaded(operation: I.() -> O): O? {
 inline fun <I, O> Loadable<I>.map(transform: (I) -> O): Loadable<O> {
     return when (this) {
         is Loadable.Loading -> Loadable.Loading()
-        is Loadable.Loaded -> Loadable.Loaded(transform(content))
+        is Loadable.Loaded -> Loadable.Loaded(transform(content), serializability)
         is Loadable.Failed -> Loadable.Failed(error)
     }
 }

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/Loadable.kt
@@ -16,14 +16,18 @@ sealed interface Loadable<T> : Serializable {
      * Stage in which the content has been successfully loaded.
      *
      * @param content Value that's been loaded.
-     * @throws NotSerializableException If [content] cannot be serialized.
+     * @param serializability Determines whether the [content] should be serializable.
+     * @throws NotSerializableException If [serializability] is [enforced][Serializability.ENFORCED]
+     * and the [content] cannot be serialized.
      **/
-    @JvmInline
-    value class Loaded<T>
+    data class Loaded<T>
     @Throws(NotSerializableException::class)
-    constructor(val content: T) : Loadable<T> {
+    constructor(
+        val content: T,
+        @PublishedApi internal val serializability: Serializability = Serializability.default
+    ) : Loadable<T> {
         init {
-            requireSerializable(content)
+            serializability.check(content)
         }
     }
 

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/LoadableScope.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/LoadableScope.extensions.kt
@@ -7,7 +7,7 @@ package com.jeanbarrossilva.loadable
  * @param send Callback run whenever a [Loadable] is sent.
  **/
 internal fun <T> LoadableScope(
-    serializability: Serializability,
+    serializability: Serializability = Serializability.default,
     send: (Loadable<T>) -> Unit
 ): LoadableScope<T> {
     return object : LoadableScope<T>() {

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/LoadableScope.extensions.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/LoadableScope.extensions.kt
@@ -3,10 +3,16 @@ package com.jeanbarrossilva.loadable
 /**
  * Creates a [LoadableScope] with [send] as its [LoadableScope.send] callback.
  *
+ * @param serializability Determines whether loaded content should be serializable.
  * @param send Callback run whenever a [Loadable] is sent.
  **/
-internal fun <T> LoadableScope(send: (Loadable<T>) -> Unit): LoadableScope<T> {
+internal fun <T> LoadableScope(
+    serializability: Serializability,
+    send: (Loadable<T>) -> Unit
+): LoadableScope<T> {
     return object : LoadableScope<T>() {
+        override val serializability = serializability
+
         override suspend fun send(loadable: Loadable<T>) {
             send(loadable)
         }

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/LoadableScope.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/LoadableScope.kt
@@ -9,7 +9,7 @@ abstract class LoadableScope<T> internal constructor() {
      *
      * @see load
      **/
-    internal abstract val serializability: Serializability
+    internal open val serializability = Serializability.default
 
     /** Sends a [Loadable.Loading]. **/
     suspend fun load() {

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/LoadableScope.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/LoadableScope.kt
@@ -4,6 +4,13 @@ import java.io.NotSerializableException
 
 /** Scope through which [Loadable]s are sent. **/
 abstract class LoadableScope<T> internal constructor() {
+    /**
+     * Determines whether loaded content should be serializable.
+     *
+     * @see load
+     **/
+    internal abstract val serializability: Serializability
+
     /** Sends a [Loadable.Loading]. **/
     suspend fun load() {
         send(Loadable.Loading())
@@ -13,11 +20,12 @@ abstract class LoadableScope<T> internal constructor() {
      * Sends a [Loadable.Loaded] with the given [content].
      *
      * @param content Value to be set as the [Loadable.Loaded.content].
-     * @throws NotSerializableException If the [content] cannot be serialized.
+     * @throws NotSerializableException If [serializability] is [enforced][Serializability.ENFORCED]
+     * and the [content] cannot be serialized.
      **/
     @Throws(NotSerializableException::class)
     suspend fun load(content: T) {
-        send(Loadable.Loaded(content))
+        send(Loadable.Loaded(content, serializability))
     }
 
     /**

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/Serializability.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/Serializability.kt
@@ -1,0 +1,51 @@
+package com.jeanbarrossilva.loadable
+
+import com.jeanbarrossilva.loadable.Serializability.ENFORCED
+import com.jeanbarrossilva.loadable.Serializability.IGNORED
+import java.io.ByteArrayOutputStream
+import java.io.NotSerializableException
+import java.io.ObjectOutputStream
+
+/**
+ * Determines whether the content held by [Loadable] and its derived structures should be
+ * serializable.
+ *
+ * @see ENFORCED
+ * @see IGNORED
+ **/
+enum class Serializability {
+    /**
+     * Indicates that [Loadable]s' and derived structures' content should be able to be serialized;
+     * if not, then a [NotSerializableException] will be thrown when they are checked.
+     *
+     * @see check
+     **/
+    ENFORCED {
+        override fun <T> check(content: T) {
+            ByteArrayOutputStream().use { byteArrayOutputStream ->
+                ObjectOutputStream(byteArrayOutputStream).use { objectOutputStream ->
+                    objectOutputStream.writeObject(content)
+                }
+            }
+        }
+    },
+
+    /**
+     * Indicates that serialization capability of [Loadable]s' and derived structures' content is
+     * ignored.
+     **/
+    IGNORED {
+        override fun <T> check(content: T) {
+        }
+    };
+
+    /**
+     * Checks whether the [content] conforms to the chosen serialization capability policy.
+     *
+     * @param content Value whose serializability will be checked.
+     * @throws NotSerializableException If the policy is [ENFORCED] and the [content] cannot be
+     * serialized.
+     **/
+    @Throws(NotSerializableException::class)
+    internal abstract fun <T> check(content: T)
+}

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/Serializability.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/Serializability.kt
@@ -47,5 +47,10 @@ enum class Serializability {
      * serialized.
      **/
     @Throws(NotSerializableException::class)
-    internal abstract fun <T> check(content: T)
+    abstract fun <T> check(content: T)
+
+    companion object {
+        /** [Serializability] that's used by default throughout the library. **/
+        val default = IGNORED
+    }
 }

--- a/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/FlowCollectorLoadableScope.kt
+++ b/loadable/src/main/java/com/jeanbarrossilva/loadable/flow/FlowCollectorLoadableScope.kt
@@ -2,6 +2,7 @@ package com.jeanbarrossilva.loadable.flow
 
 import com.jeanbarrossilva.loadable.Loadable
 import com.jeanbarrossilva.loadable.LoadableScope
+import com.jeanbarrossilva.loadable.Serializability
 import kotlinx.coroutines.flow.FlowCollector
 
 /**
@@ -11,6 +12,7 @@ import kotlinx.coroutines.flow.FlowCollector
  **/
 @PublishedApi
 internal class FlowCollectorLoadableScope<T>(
+    override val serializability: Serializability,
     private val collector: FlowCollector<Loadable<T>>
 ) : LoadableScope<T>() {
     override suspend fun send(loadable: Loadable<T>) {

--- a/loadable/src/test/java/com/jeanbarrossilva/loadable/AnyExtensionsTests.kt
+++ b/loadable/src/test/java/com/jeanbarrossilva/loadable/AnyExtensionsTests.kt
@@ -1,9 +1,7 @@
 package com.jeanbarrossilva.loadable
 
-import java.io.NotSerializableException
 import java.util.Stack
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import org.junit.Assert.assertEquals
@@ -33,17 +31,5 @@ internal class AnyExtensionsTests {
     @Test
     fun `GIVEN a non-null object WHEN converting it into a Loadable of a different type THEN it's null`() { // ktlint-disable max-line-length
         assertNull(0.loadable<Array<Stack<String>>>())
-    }
-
-    @Test
-    fun `GIVEN an un-serializable object WHEN requiring it to be serializable THEN it throws`() {
-        assertFailsWith<NotSerializableException> {
-            requireSerializable(Thread.UncaughtExceptionHandler { _, _ -> })
-        }
-    }
-
-    @Test
-    fun `GIVEN a serializable object WHEN requiring it to be serializable THEN it is`() {
-        requireSerializable(listOf(1, 2, 3))
     }
 }

--- a/loadable/src/test/java/com/jeanbarrossilva/loadable/LoadableScopeTests.kt
+++ b/loadable/src/test/java/com/jeanbarrossilva/loadable/LoadableScopeTests.kt
@@ -8,7 +8,7 @@ import org.junit.Test
 
 internal class LoadableScopeTests {
     private val sent = mutableListOf<Loadable<Any?>>()
-    private val scope: LoadableScope<Any?> = LoadableScope(sent::add)
+    private val scope: LoadableScope<Any?> = LoadableScope(send = sent::add)
 
     @After
     fun tearDown() {

--- a/loadable/src/test/java/com/jeanbarrossilva/loadable/SerializabilityTests.kt
+++ b/loadable/src/test/java/com/jeanbarrossilva/loadable/SerializabilityTests.kt
@@ -1,0 +1,29 @@
+package com.jeanbarrossilva.loadable
+
+import java.io.NotSerializableException
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+internal class SerializabilityTests {
+    @Test
+    fun `GIVEN the enforced policy WHEN checking unserializable content THEN it throws`() {
+        assertFailsWith<NotSerializableException> {
+            Serializability.ENFORCED.check(Thread.UncaughtExceptionHandler { _, _ -> })
+        }
+    }
+
+    @Test
+    fun `GIVEN the enforced policy WHEN checking serializable content THEN it does not throw`() {
+        Serializability.ENFORCED.check("Hello, world!")
+    }
+
+    @Test
+    fun `GIVEN the ignored policy WHEN checking unserializable content THEN it does not throw`() {
+        Serializability.IGNORED.check(Thread.UncaughtExceptionHandler { _, _ -> })
+    }
+
+    @Test
+    fun `GIVEN the ignored policy WHEN checking serializable content THEN it does not throw`() {
+        Serializability.IGNORED.check("Hello, world!")
+    }
+}

--- a/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
+++ b/loadable/src/test/java/com/jeanbarrossilva/loadable/flow/FlowExtensionsTests.kt
@@ -197,7 +197,7 @@ internal class FlowExtensionsTests {
     @Test
     fun `GIVEN a Loadable Flow that's Loading WHEN sending its Loadables into a LoadableScope THEN it loads`() { // ktlint-disable max-line-length
         runTest {
-            emptyLoadableFlow(loadableFlow<Any?>()::sendTo).test {
+            emptyLoadableFlow(load = loadableFlow<Any?>()::sendTo).test {
                 assertIs<Loadable.Loading<Any?>>(awaitItem())
             }
         }
@@ -207,7 +207,7 @@ internal class FlowExtensionsTests {
     @Test
     fun `GIVEN a Loadable Flow that's Loaded WHEN sending its Loadables into a LoadableScope THEN it loads the content`() { // ktlint-disable max-line-length
         runTest {
-            loadableFlow(loadableFlowOf(0)::sendTo).test {
+            loadableFlow(load = loadableFlowOf(0)::sendTo).test {
                 awaitItem()
                 assertEquals(Loadable.Loaded(0), awaitItem())
             }


### PR DESCRIPTION
Allows external consumers to specify whether serializability should be enforced or ignored.