### PR TITLE
Opt-in serializability enforcement on `Collection#toSerializableList`

### DIFF
--- a/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/Collection.extensions.kt
+++ b/loadable-list/src/main/java/com/jeanbarrossilva/loadable/list/Collection.extensions.kt
@@ -1,13 +1,18 @@
 package com.jeanbarrossilva.loadable.list
 
+import com.jeanbarrossilva.loadable.Serializability
 import java.io.NotSerializableException
 
 /**
  * Converts this [Collection] it into a [SerializableList].
  *
- * @throws NotSerializableException If any of the elements cannot be serialized.
+ * @param serializability Determines whether each of the elements should be serializable.
+ * @throws NotSerializableException If [serializability] is [enforced][Serializability.ENFORCED] and
+ * any of the elements cannot be serialized.
  **/
 @Throws(NotSerializableException::class)
-inline fun <reified T> Collection<T>.toSerializableList(): SerializableList<T> {
-    return toTypedArray().toSerializableList()
+inline fun <reified T> Collection<T>.toSerializableList(
+    serializability: Serializability = Serializability.default
+): SerializableList<T> {
+    return toTypedArray().toSerializableList(serializability)
 }


### PR DESCRIPTION
Converter function did not have a [`Serializability`](https://github.com/jeanbarrossilva/loadable/blob/c937dfd121d127e92bb469e654c8bdffb9e222a7/loadable/src/main/java/com/jeanbarrossilva/loadable/Serializability.kt) parameter added to it in the previous PR.